### PR TITLE
Add extra cost command

### DIFF
--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -1167,6 +1167,17 @@ var _ = register(lbsPostChatMessage, func(p *LbsPeer, m *LbsMessage) {
 			}
 		}
 
+		hintMsgBuilder := func(hint string) *LbsMessage {
+			return NewServerNotice(lbsChatMessage).Writer().
+				WriteString("").
+				WriteString("").
+				WriteString(hint).
+				Write8(0).      // chat_type
+				Write8(0).      // id color
+				Write8(0).      // handle color
+				Write8(0).Msg() // msg color
+		}
+
 		if text == "／ｆ" || text == "／Ｆ" {
 			//intercept message if it is a command
 
@@ -1188,17 +1199,6 @@ var _ = register(lbsPostChatMessage, func(p *LbsPeer, m *LbsMessage) {
 				//only print unaccepted command + hint to sender
 				p.SendMessage(msg)
 
-				hintMsgBuilder := func(hint string) *LbsMessage {
-					return NewServerNotice(lbsChatMessage).Writer().
-						WriteString("").
-						WriteString("").
-						WriteString(hint).
-						Write8(0). // chat_type
-						Write8(0). // id color
-						Write8(0). // handle color
-						Write8(0).Msg() // msg color
-				}
-
 				if userHasJoinedForce == false {
 					hint := hintMsgBuilder("Join a force first! (自動選抜→待機)")
 					p.SendMessage(hint)
@@ -1208,6 +1208,18 @@ var _ = register(lbsPostChatMessage, func(p *LbsPeer, m *LbsMessage) {
 				}
 
 			}
+		} else if text == "／ｅｃ" || text == "／ＥＣ" {
+			//Extra Cost
+			postInLobby(msg)
+			hint := hintMsgBuilder("Cost is set to 630!")
+			postInLobby(hint)
+			p.Lobby.EnableExtraCost()
+		} else if text == "／ｎｃ" || text == "／ＮＣ" {
+			//Normal cost
+			postInLobby(msg)
+			hint := hintMsgBuilder("Cost is set to 600!")
+			postInLobby(hint)
+			p.Lobby.DisableExtraCost()
 		} else {
 			postInLobby(msg)
 		}


### PR DESCRIPTION
By using the `／ｅｃ`, player can enable Extra Cost (630) for the next battle, `／ｎｃ` to revert to Normal Cost (600).

If there is no battle happen after 180 seconds, lobby will be reverted to normal cost

<img width="503" alt="Screenshot 2020-09-27 at 5 36 21 PM" src="https://user-images.githubusercontent.com/602245/94361598-fdc62a00-00e7-11eb-9a91-77d95060256f.png">


The extra 30 cost can enable extra combinations for fun:

![combo](https://user-images.githubusercontent.com/602245/94362156-ea1cc280-00eb-11eb-9bcd-d83db1cce6cb.jpg)

ゲルググGELGOOG is not enabled for balance, and unfortunately ギャンGYAN has the same cost.
(Since ゲルググ & ギャン's cost = 300, 375+300=675 > 630)

Extra Cost value is open for discussion, if we want to include ゲルググGELGOOG & ギャンGYAN, the value would be 680.