### PR TITLE
Add back Taiwan for JP vs HK

### DIFF
--- a/gdxsv/lbs_lobby_setting.go
+++ b/gdxsv/lbs_lobby_setting.go
@@ -101,9 +101,10 @@ func init() {
 		},
 		12: {
 			Name:                "地下基地",
-			McsRegion:           "asia-southeast1",
+			McsRegion:           "asia-east1",
 			EnableForceStartCmd: true,
 			EnableExtraCostCmd:  true,
+			Comment:             "日本vs香港専用",
 		},
 
 		// space lobbies


### PR DESCRIPTION
I would recommend Taiwan server over Seoul since TW is in the middle of JP and HK.

And the latency from Osaka is even lower than from Seoul for Hong Kong players.