### PR TITLE
Publish server status to Discord thru webhook

### DIFF
--- a/build_run.sh
+++ b/build_run.sh
@@ -14,7 +14,7 @@ export GDXSV_BATTLE_PUBLIC_ADDR="192.168.1.10:9877"
 export GDXSV_BATTLE_ADDR="localhost:9877"
 export GDXSV_MCSFUNC_KEY="${HOME}/keys/gdxsv-service-key.json"
 export GDXSV_MCSFUNC_URL="https://asia-northeast1-gdxsv-274515.cloudfunctions.net/mcsfunc"
-export GDXSV_DISCORD_WEBHOOK_URL="{PASTE_WEBHOOK_URL_HERE}/messages/{PASTE_TARGET_MESSAGE_ID_HERE}"
+export GDXSV_DISCORD_LIVESTATUS_WEBHOOK_URL="{PASTE_WEBHOOK_URL_HERE}/messages/{PASTE_TARGET_MESSAGE_ID_HERE}"
 
 #./bin/gdxsv -v 3 lbs -profile 1 2>&1 | tee log.txt
 ./bin/gdxsv -v 3 lbs 2>&1 | tee log.txt

--- a/build_run.sh
+++ b/build_run.sh
@@ -14,6 +14,7 @@ export GDXSV_BATTLE_PUBLIC_ADDR="192.168.1.10:9877"
 export GDXSV_BATTLE_ADDR="localhost:9877"
 export GDXSV_MCSFUNC_KEY="${HOME}/keys/gdxsv-service-key.json"
 export GDXSV_MCSFUNC_URL="https://asia-northeast1-gdxsv-274515.cloudfunctions.net/mcsfunc"
+export GDXSV_DISCORD_WEBHOOK_URL="{PASTE_WEBHOOK_URL_HERE}/messages/{PASTE_TARGET_MESSAGE_ID_HERE}"
 
 #./bin/gdxsv -v 3 lbs -profile 1 2>&1 | tee log.txt
 ./bin/gdxsv -v 3 lbs 2>&1 | tee log.txt

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -378,6 +378,7 @@ func (lbs *Lbs) BroadcastLobbyUserCount(lobby *LbsLobby) {
 			}
 		}
 	}
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
@@ -390,6 +391,7 @@ func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
 			p.SendMessage(msg2)
 		}
 	}
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
@@ -406,6 +408,7 @@ func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
 			}
 		}
 	}
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) RegisterBattleResult(p *LbsPeer, result *BattleResult) {

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -378,7 +378,7 @@ func (lbs *Lbs) BroadcastLobbyUserCount(lobby *LbsLobby) {
 			}
 		}
 	}
-	go lbs.PublishStatusToDiscord()
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
@@ -391,7 +391,7 @@ func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
 			p.SendMessage(msg2)
 		}
 	}
-	go lbs.PublishStatusToDiscord()
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
@@ -408,7 +408,7 @@ func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
 			}
 		}
 	}
-	go lbs.PublishStatusToDiscord()
+	lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) RegisterBattleResult(p *LbsPeer, result *BattleResult) {

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -91,6 +91,9 @@ func (lbs *Lbs) ListenAndServe(addr string) error {
 		return err
 	}
 	go lbs.eventLoop()
+	if len(conf.DiscordLiveStatusWebhookURL) > 0 {
+		go lbs.publishLiveStatusToDiscordLoop()
+	}
 	for {
 		tcpConn, err := listener.AcceptTCP()
 		if err != nil {
@@ -220,6 +223,7 @@ func (lbs *Lbs) cleanPeer(p *LbsPeer) {
 
 	p.conn.Close()
 	p.left = true
+	discordLiveStatusUpdateAvailable = true
 }
 
 func (lbs *Lbs) eventLoop() {
@@ -378,7 +382,7 @@ func (lbs *Lbs) BroadcastLobbyUserCount(lobby *LbsLobby) {
 			}
 		}
 	}
-	lbs.PublishLiveStatusToDiscord()
+	discordLiveStatusUpdateAvailable = true
 }
 
 func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
@@ -391,7 +395,7 @@ func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
 			p.SendMessage(msg2)
 		}
 	}
-	lbs.PublishLiveStatusToDiscord()
+	discordLiveStatusUpdateAvailable = true
 }
 
 func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
@@ -408,7 +412,7 @@ func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
 			}
 		}
 	}
-	lbs.PublishLiveStatusToDiscord()
+	discordLiveStatusUpdateAvailable = true
 }
 
 func (lbs *Lbs) RegisterBattleResult(p *LbsPeer, result *BattleResult) {

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -378,7 +378,7 @@ func (lbs *Lbs) BroadcastLobbyUserCount(lobby *LbsLobby) {
 			}
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	go lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
@@ -391,7 +391,7 @@ func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
 			p.SendMessage(msg2)
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	go lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
@@ -408,7 +408,7 @@ func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
 			}
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	go lbs.PublishStatusToDiscord()
 }
 
 func (lbs *Lbs) RegisterBattleResult(p *LbsPeer, result *BattleResult) {

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -378,7 +378,7 @@ func (lbs *Lbs) BroadcastLobbyUserCount(lobby *LbsLobby) {
 			}
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	lbs.PublishLiveStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
@@ -391,7 +391,7 @@ func (lbs *Lbs) BroadcastLobbyMatchEntryUserCount(lobby *LbsLobby) {
 			p.SendMessage(msg2)
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	lbs.PublishLiveStatusToDiscord()
 }
 
 func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
@@ -408,7 +408,7 @@ func (lbs *Lbs) BroadcastRoomState(room *LbsRoom) {
 			}
 		}
 	}
-	lbs.PublishStatusToDiscord()
+	lbs.PublishLiveStatusToDiscord()
 }
 
 func (lbs *Lbs) RegisterBattleResult(p *LbsPeer, result *BattleResult) {

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"math"
 	"net/http"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -137,10 +136,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 	}
 
 	reduceJSONStringSize := func(s string) string {
-		//Reduce size by removing userid
-		re := regexp.MustCompile("`.*?`\\s")
-		s = re.ReplaceAllString(s, "")
-
+		//Reduce size by using standard emoji
 		replacer := strings.NewReplacer("<:gundam:772467554160738355>", "🌎", "<:zaku:772467605008023563>", "🪐")
 		s = replacer.Replace(s)
 

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -513,6 +513,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 	//Publish Loop
 	//
 	tick := time.Tick(3 * time.Second)
+	tok := time.Tick(5 * time.Minute)
 	for {
 		select {
 		case <-tick:
@@ -520,6 +521,9 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 				discordLiveStatusUpdateAvailable = false
 				publish()
 			}
+		case <-tok:
+			discordLiveStatusUpdateAvailable = false
+			publish()
 		}
 	}
 }

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"regexp"
@@ -442,5 +443,14 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 		logger.Error("Failed to publish to Discord", zap.Error(err))
 	}
 	defer resp.Body.Close()
+
 	logger.Info("Discord Webhook sent", zap.String("Status", resp.Status))
+	if resp.Status == "400 Bad Request" {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			logger.Error("Failed to read response body", zap.Error(err))
+			return
+		}
+		logger.Error("Failed to create Discord JSON", zap.String("Error:", string(body)))
+	}
 }

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -22,7 +22,7 @@ var discordLiveStatusIsPublishing uint32
 
 //PublishLiveStatusToDiscord : Update server status to the predefined Discord message thru Web Hook
 func (lbs *Lbs) PublishLiveStatusToDiscord() {
-	if len(conf.DiscordWebhookURL) == 0 {
+	if len(conf.DiscordLiveStatusWebhookURL) == 0 {
 		return
 	}
 
@@ -451,7 +451,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		var send func(buf *bytes.Buffer)
 		send = func(buf *bytes.Buffer) {
 
-			req, err := http.NewRequest("PATCH", conf.DiscordWebhookURL, buf)
+			req, err := http.NewRequest("PATCH", conf.DiscordLiveStatusWebhookURL, buf)
 			req.Header.Set("Content-Type", "application/json")
 
 			resp, err := http.DefaultClient.Do(req)

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -243,7 +243,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 						lobby[u.Lobby.ID].RegionName = locName
 
 						var comment string
-						if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
+						if u.Lobby.TeamShuffle {
 							comment += "🔀"
 						}
 						if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
@@ -252,11 +252,18 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 						if strings.Contains(u.Lobby.Comment, "Private Room") {
 							comment += "🔒"
 						}
-						if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
+						if u.Lobby.No375MS {
 							comment += "⛔375"
 						}
-						if strings.Contains(u.Lobby.Comment, "3R") {
+						switch u.Lobby.AutoReBattle {
+						case 2:
+							comment += "2️⃣"
+						case 3:
 							comment += "3️⃣"
+						case 4:
+							comment += "4️⃣"
+						case 5:
+							comment += "5️⃣"
 						}
 
 						lobby[u.Lobby.ID].Comment = comment

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -29,6 +29,9 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 	// Core function for Discord webhook
 	var publish func()
 
+	//
+	// Ensure only 1 publishing job can be run, block all other requests
+	//
 	if atomic.CompareAndSwapUint32(&discordLiveStatusIsPublishing, 0, 1) {
 		go func() {
 			publish()

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -461,8 +461,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		//
 		// Send to Discord
 		//
-		var send func(buf *bytes.Buffer)
-		send = func(buf *bytes.Buffer) {
+		send := func(buf *bytes.Buffer) {
 
 			req, err := http.NewRequest("PATCH", conf.DiscordLiveStatusWebhookURL, buf)
 			req.Header.Set("Content-Type", "application/json")
@@ -474,12 +473,12 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 			}
 			defer resp.Body.Close()
 
-			ratelimitRemaining := resp.Header.Get("x-ratelimit-remaining")
-			if len(ratelimitRemaining) > 0 {
+			if ratelimitRemaining := resp.Header.Get("x-ratelimit-remaining"); len(ratelimitRemaining) > 0 {
 				discordLiveStatusRateRemaining, _ = strconv.Atoi(ratelimitRemaining)
 			}
-			ratelimitReset := resp.Header.Get("x-ratelimit-reset")
-			discordLiveStatusRateResetEpoch, _ = strconv.ParseInt(ratelimitReset, 10, 64)
+			if ratelimitReset := resp.Header.Get("x-ratelimit-reset"); len(ratelimitReset) > 0 {
+				discordLiveStatusRateResetEpoch, _ = strconv.ParseInt(ratelimitReset, 10, 64)
+			}
 
 			logger.Info("Discord Webhook sent", zap.String("Status", resp.Status))
 			if resp.StatusCode == http.StatusBadRequest {

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -20,14 +20,6 @@ import (
 var retryTimer *time.Timer
 var jobIsRunning uint32
 
-type onlineUser struct {
-	UserID     string `json:"user_id,omitempty"`
-	Name       string `json:"name,omitempty"`
-	Team       string `json:"team,omitempty"`
-	BattleCode string `json:"battle_code,omitempty"`
-	Disk       string `json:"disk,omitempty"`
-}
-
 type discordEmbedFooter struct {
 	Text string `json:"text,omitempty"`
 }

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+)
+
+const rateLimit = time.Second
+
+var discordRequestGroup singleflight.Group
+
+func (lbs *Lbs) PublishStatusToDiscord() {
+	if len(conf.DiscordWebhookURL) == 0 {
+		return
+	}
+
+	contains := func(s []string, e string) bool {
+		for _, a := range s {
+			if a == e {
+				return true
+			}
+		}
+		return false
+	}
+
+	//insert Braille Pattern Blank to create newline at ending
+	addBlankIfRequired := func(s string) string {
+		if strings.HasSuffix(s, "\n") {
+			return s + "⠀"
+		}
+		return s
+	}
+
+	type onlineUser struct {
+		UserID     string `json:"user_id,omitempty"`
+		Name       string `json:"name,omitempty"`
+		Team       string `json:"team,omitempty"`
+		BattleCode string `json:"battle_code,omitempty"`
+		Disk       string `json:"disk,omitempty"`
+	}
+
+	type DiscordEmbedFooter struct {
+		Text string `json:"text,omitempty"`
+	}
+
+	type DiscordEmbedField struct {
+		Name   string `json:"name,omitempty"`
+		Value  string `json:"value,omitempty"`
+		Inline bool   `json:"inline,omitempty"`
+	}
+
+	type DiscordEmbed struct {
+		Title       string               `json:"title,omitempty"`
+		Description string               `json:"description,omitempty"`
+		Color       int                  `json:"color,omitempty"`
+		Footer      *DiscordEmbedFooter  `json:"footer,omitempty"`
+		Timestamp   string               `json:"timestamp,omitempty"`
+		Fields      []*DiscordEmbedField `json:"fields,omitempty"`
+	}
+
+	type statusPayload struct {
+		Embed   []*DiscordEmbed `json:"embeds"`
+		BotName string          `json:"username"`
+	}
+
+	payload, _, _ := discordRequestGroup.Do("discord_webhook_publish", func() (interface{}, error) {
+		type BattlePeers struct {
+			RegionName string
+			RenpoPeers string
+			ZeonPeers  string
+		}
+		battle := make(map[string]*BattlePeers)
+
+		battlePeerCount := 0
+		var battlePeersIDs string
+		for _, u := range sharedData.GetMcsUsers() {
+			_, exists := battle[u.BattleCode]
+			if exists == false {
+				battle[u.BattleCode] = new(BattlePeers)
+
+				locName, ok := gcpLocationName[u.McsRegion]
+				if !ok {
+					locName = "Default Server"
+				}
+				if u.McsRegion == "best" {
+					locName = "Best Server [Auto Detection]"
+				}
+				battle[u.BattleCode].RegionName = locName
+			}
+
+			switch u.Side {
+			case TeamRenpo:
+				battle[u.BattleCode].RenpoPeers += fmt.Sprintf("<:gundam:772467554160738355> `%s` %s\n", u.UserID, u.Name)
+			case TeamZeon:
+				battle[u.BattleCode].ZeonPeers += fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
+			}
+
+			battlePeerCount++
+			battlePeersIDs += u.UserID
+		}
+		var plazaPeers string
+		type LobbyPeers struct {
+			Count          int
+			Name           string
+			RegionName     string
+			Comment        string
+			RenpoPeers     string
+			ZeonPeers      string
+			RenpoRoomPeers string
+			ZeonRoomPeers  string
+			NoForcePeers   string
+		}
+		lobby := make(map[uint16]*LobbyPeers)
+
+		plazaPeerCount := 0
+		lobbyPeerCount := 0
+		for _, u := range lbs.userPeers {
+
+			//Already in battle, hidden from lobby
+			if strings.Contains(battlePeersIDs, u.UserID) {
+				continue
+			}
+
+			if u.Lobby == nil {
+				plazaPeers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
+				plazaPeerCount++
+			} else {
+				_, exists := lobby[u.Lobby.ID]
+				if exists == false {
+					lobby[u.Lobby.ID] = new(LobbyPeers)
+					lobby[u.Lobby.ID].Name = u.Lobby.Name
+
+					locName, ok := gcpLocationName[u.Lobby.McsRegion]
+					if !ok {
+						locName = "Default Server"
+					}
+					if u.Lobby.McsRegion == "best" {
+						locName = "Best Server [Auto Detection]"
+					}
+					lobby[u.Lobby.ID].RegionName = locName
+
+					var comment string
+					if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
+						comment += "🔀"
+					}
+					if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
+						comment += "( 🇯🇵 vs 🇭🇰 )"
+					}
+					if strings.Contains(u.Lobby.Comment, "Private Room") {
+						comment += "🔒"
+					}
+					if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
+						comment += "⛔375"
+					}
+					if strings.Contains(u.Lobby.Comment, "3R") {
+						comment += "3️⃣"
+					}
+
+					lobby[u.Lobby.ID].Comment = comment
+				}
+
+				var readyColor string
+				if contains(u.Lobby.EntryUsers, u.UserID) {
+					readyColor = "🟢"
+				} else {
+					readyColor = "🔴"
+				}
+				if u.Room != nil {
+					readyColor = "📢"
+				}
+
+				switch u.Team {
+				case TeamRenpo:
+					lobby[u.Lobby.ID].RenpoPeers += fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+				case TeamZeon:
+					lobby[u.Lobby.ID].ZeonPeers += fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+				default:
+					lobby[u.Lobby.ID].NoForcePeers += fmt.Sprintf(":grey_question::black_circle: `%s` %s\n", u.UserID, u.Name)
+				}
+
+				lobby[u.Lobby.ID].Count++
+			}
+			lobbyPeerCount++
+		}
+
+		payload := new(statusPayload)
+		payload.BotName = "Live Status"
+
+		//1st Embed, online count
+		payload.Embed = append(payload.Embed, &DiscordEmbed{
+			Title:     fmt.Sprintf("**同時接続数 %d 人 **", lobbyPeerCount+battlePeerCount),
+			Color:     52224,
+			Footer:    &DiscordEmbedFooter{Text: "🕒"},
+			Timestamp: fmt.Sprintf(time.Now().UTC().Format("2006-01-02T15:04:05.000Z")),
+		})
+
+		//2nd Embed, lobby count
+		var lobbyFields []*DiscordEmbedField
+		if plazaPeerCount > 0 {
+			lobbyFields = append(lobbyFields, &DiscordEmbedField{
+				Name:  fmt.Sprintf("**Plaza － %d 人**", plazaPeerCount),
+				Value: plazaPeers + "⠀", //insert Braille Pattern Blank to create newline at ending
+			})
+		}
+		for _, l := range lobby {
+			lobbyFields = append(lobbyFields, &DiscordEmbedField{
+				Name:  fmt.Sprintf("**%s － %d 人\n%s %s**", l.Name, l.Count, l.RegionName, l.Comment),
+				Value: l.RenpoPeers + addBlankIfRequired(l.ZeonPeers) + l.RenpoRoomPeers + addBlankIfRequired(l.ZeonRoomPeers) + addBlankIfRequired(l.NoForcePeers),
+			})
+		}
+		payload.Embed = append(payload.Embed, &DiscordEmbed{
+			Description: fmt.Sprintf("🌐 **待機中 %d 人**", lobbyPeerCount),
+			Color:       24041,
+			Fields:      lobbyFields,
+		})
+
+		//3rd Embed, battle count
+		var battleFields []*DiscordEmbedField
+		for _, b := range battle {
+			battleFields = append(battleFields, &DiscordEmbedField{
+				Name:  b.RegionName,
+				Value: b.RenpoPeers + addBlankIfRequired(b.ZeonPeers),
+			})
+		}
+		payload.Embed = append(payload.Embed, &DiscordEmbed{
+			Description: fmt.Sprintf("💥 **戦闘中 %d 人**", battlePeerCount),
+			Color:       13179394,
+			Fields:      battleFields,
+		})
+
+		return payload, nil
+	})
+
+	var jsonData []byte
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		logger.Error("Failed to create Discord JSON", zap.Error(err))
+	}
+	logger.Info(string(jsonData))
+
+	req, err := http.NewRequest("PATCH", conf.DiscordWebhookURL, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error("Failed to publish to Discord", zap.Error(err))
+	}
+	defer resp.Body.Close()
+	logger.Info("Discord Webhook done", zap.String("Status", resp.Status))
+}

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -462,14 +462,14 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 			defer resp.Body.Close()
 
 			logger.Info("Discord Webhook sent", zap.String("Status", resp.Status))
-			if resp.Status == "400 Bad Request" {
+			if resp.StatusCode == http.StatusBadRequest {
 				body, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
 					logger.Error("Failed to read response body", zap.Error(err))
 					return
 				}
 				logger.Error("Failed to create Discord JSON", zap.String("Error:", string(body)))
-			} else if resp.Status == "429 Too Many Requests" {
+			} else if resp.StatusCode == http.StatusTooManyRequests {
 
 				resetepochTime := resp.Header.Get("x-ratelimit-reset")
 				sec, _ := strconv.ParseInt(resetepochTime, 10, 64)

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -17,478 +17,498 @@ import (
 	"go.uber.org/zap"
 )
 
-var retryTimer *time.Timer
-var jobIsRunning uint32
+var discordLiveStatusRetryTimer *time.Timer
+var discordLiveStatusIsPublishing uint32
 
-type discordEmbedFooter struct {
-	Text string `json:"text,omitempty"`
-}
-
-type discordEmbedField struct {
-	Name   string `json:"name,omitempty"`
-	Value  string `json:"value,omitempty"`
-	Inline bool   `json:"inline,omitempty"`
-}
-
-type discordEmbed struct {
-	Title       string               `json:"title,omitempty"`
-	Description string               `json:"description,omitempty"`
-	Color       int                  `json:"color,omitempty"`
-	Footer      *discordEmbedFooter  `json:"footer,omitempty"`
-	Timestamp   string               `json:"timestamp,omitempty"`
-	Fields      []*discordEmbedField `json:"fields,omitempty"`
-}
-
-type statusPayload struct {
-	Embed   []*discordEmbed `json:"embeds"`
-	BotName string          `json:"username"`
-}
-
-type lobbyPeers struct {
-	Count          int
-	Name           string
-	RegionName     string
-	Comment        string
-	RenpoPeers     string
-	ZeonPeers      string
-	RenpoRoomPeers string
-	ZeonRoomPeers  string
-	NoForcePeers   string
-}
-
-type battlePeers struct {
-	RegionName string
-	RenpoPeers string
-	ZeonPeers  string
-}
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
-func sortedKeys(m map[uint16]*lobbyPeers) []uint16 {
-	keys := make([]uint16, len(m))
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
-	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	return keys
-}
-
-//insert Braille Pattern Blank to create newline at ending
-func addBlankIfRequired(s string) string {
-	if len(s) > 0 {
-		return s + "⠀\n"
-	}
-	return s
-}
-
-//Embed limits: Field's value is limited toto 1024 characters
-func splitEmbedFieldValues(value string) []string {
-	var values []string
-
-	//Split field values into 1024 chunks
-	numberOfSplit := int(math.Ceil(float64(len(value)) / 1024))
-
-	splitIndex := 0
-	for i := 0; i < numberOfSplit; i++ {
-		splitIndex = len(value) / (numberOfSplit - i)
-		firstHalf := value[:splitIndex]
-		splitIndex = strings.LastIndex(firstHalf, "\n")
-
-		values = append(values, value[:splitIndex])
-		// splitIndex += 2
-		value = value[splitIndex:]
-	}
-	//do not create empty fields
-	if value != "\n" {
-		values = append(values, value)
-	}
-
-	return values
-}
-
-//Embed limits: There can be up to 25 fields
-func splitEmbedFields(fields []*discordEmbedField) [][]*discordEmbedField {
-	var divided [][]*discordEmbedField
-	chunkSize := 25
-
-	for i := 0; i < len(fields); i += chunkSize {
-		end := i + chunkSize
-
-		if end > len(fields) {
-			end = len(fields)
-		}
-
-		divided = append(divided, fields[i:end])
-	}
-	return divided
-}
-
-func reducePeerStringSize(s string) string {
-	//Reduce size by removing userid
-	re := regexp.MustCompile("`.*?`\\s")
-	s = re.ReplaceAllString(s, "")
-
-	//Reduce size by replacing custom emoji (from 28 char to 1 char)
-	s = strings.ReplaceAll(s, "<:gundam:772467554160738355>", "🌎")
-	s = strings.ReplaceAll(s, "<:zaku:772467605008023563>", "🪐")
-
-	return s
-}
-
-//PublishStatusToDiscord : Update server status to the predefined Discord message thru Web Hook
-func (lbs *Lbs) PublishStatusToDiscord() {
+//PublishLiveStatusToDiscord : Update server status to the predefined Discord message thru Web Hook
+func (lbs *Lbs) PublishLiveStatusToDiscord() {
 	if len(conf.DiscordWebhookURL) == 0 {
 		return
 	}
 
-	if atomic.CompareAndSwapUint32(&jobIsRunning, 0, 1) {
+	// Core function for Discord webhook
+	var publish func()
+
+	if atomic.CompareAndSwapUint32(&discordLiveStatusIsPublishing, 0, 1) {
 		go func() {
-			publish(lbs)
-			atomic.StoreUint32(&jobIsRunning, 0)
+			publish()
+			atomic.StoreUint32(&discordLiveStatusIsPublishing, 0)
 		}()
 	} else {
 		logger.Info("Request blocked!")
-		if retryTimer != nil {
-			retryTimer.Stop()
+		if discordLiveStatusRetryTimer != nil {
+			discordLiveStatusRetryTimer.Stop()
 		}
 		//Retry last blocked request after 0.5s
-		retryTimer = time.AfterFunc(time.Second/2, func() {
+		discordLiveStatusRetryTimer = time.AfterFunc(time.Second/2, func() {
 			logger.Info("Retrying!")
-			publish(lbs)
+			publish()
 		})
 	}
-}
 
-func publish(lbs *Lbs) {
+	//
+	//Type definition
+	//
+	type discordEmbedFooter struct {
+		Text string `json:"text,omitempty"`
+	}
 
-	//Stop any retry request since new request appeared
-	if retryTimer != nil {
-		retryTimer.Stop()
-		retryTimer = nil
+	type discordEmbedField struct {
+		Name   string `json:"name,omitempty"`
+		Value  string `json:"value,omitempty"`
+		Inline bool   `json:"inline,omitempty"`
+	}
+
+	type discordEmbed struct {
+		Title       string               `json:"title,omitempty"`
+		Description string               `json:"description,omitempty"`
+		Color       int                  `json:"color,omitempty"`
+		Footer      *discordEmbedFooter  `json:"footer,omitempty"`
+		Timestamp   string               `json:"timestamp,omitempty"`
+		Fields      []*discordEmbedField `json:"fields,omitempty"`
+	}
+
+	type statusPayload struct {
+		Embed   []*discordEmbed `json:"embeds"`
+		BotName string          `json:"username"`
+	}
+
+	type lobbyUsers struct {
+		Count          int
+		Name           string
+		RegionName     string
+		Comment        string
+		RenpoPeers     string
+		ZeonPeers      string
+		RenpoRoomPeers string
+		ZeonRoomPeers  string
+		NoForcePeers   string
+	}
+
+	type battleUsers struct {
+		RegionName string
+		RenpoPeers string
+		ZeonPeers  string
 	}
 
 	//
-	// Create battle peer list, for the third embed
+	// Helper function
 	//
-	battle := make(map[string]*battlePeers)
-
-	battlePeerCount := 0
-	var battlePeersIDs string
-	var accumulatedBattlePeersString string
-
-	for _, u := range sharedData.GetMcsUsers() {
-		_, exists := battle[u.BattleCode]
-		if exists == false {
-			battle[u.BattleCode] = new(battlePeers)
-
-			locName, ok := gcpLocationName[u.McsRegion]
-			if !ok {
-				locName = "Default Server"
+	contains := func(s []string, e string) bool {
+		for _, a := range s {
+			if a == e {
+				return true
 			}
-			if u.McsRegion == "best" {
-				locName = "Best Server"
-			}
-			battle[u.BattleCode].RegionName = locName
-			accumulatedBattlePeersString += locName
+		}
+		return false
+	}
+
+	sortedKeys := func(m map[uint16]*lobbyUsers) []uint16 {
+		keys := make([]uint16, len(m))
+		i := 0
+		for k := range m {
+			keys[i] = k
+			i++
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		return keys
+	}
+
+	//insert Braille Pattern Blank to create newline at ending
+	addBlankIfRequired := func(s string) string {
+		if len(s) > 0 {
+			return s + "⠀\n"
+		}
+		return s
+	}
+
+	//Embed limits: Field's value is limited toto 1024 characters
+	splitEmbedFieldValues := func(value string) []string {
+		var values []string
+
+		//Split field values into 1024 chunks
+		numberOfSplit := int(math.Ceil(float64(len(value)) / 1024))
+
+		splitIndex := 0
+		for i := 0; i < numberOfSplit; i++ {
+			splitIndex = len(value) / (numberOfSplit - i)
+			firstHalf := value[:splitIndex]
+			splitIndex = strings.LastIndex(firstHalf, "\n")
+
+			values = append(values, value[:splitIndex])
+			// splitIndex += 2
+			value = value[splitIndex:]
+		}
+		//do not create empty fields
+		if value != "\n" {
+			values = append(values, value)
 		}
 
-		var peer string
-		switch u.Side {
-		case TeamRenpo:
-			peer = fmt.Sprintf("<:gundam:772467554160738355> `%s` %s\n", u.UserID, u.Name)
-			battle[u.BattleCode].RenpoPeers += peer
-		case TeamZeon:
-			peer = fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
-			battle[u.BattleCode].ZeonPeers += peer
-		}
-		accumulatedBattlePeersString += peer
+		return values
+	}
 
-		battlePeerCount++
-		battlePeersIDs += u.UserID
+	//Embed limits: There can be up to 25 fields
+	splitEmbedFields := func(fields []*discordEmbedField) [][]*discordEmbedField {
+		var divided [][]*discordEmbedField
+		chunkSize := 25
+
+		for i := 0; i < len(fields); i += chunkSize {
+			end := i + chunkSize
+
+			if end > len(fields) {
+				end = len(fields)
+			}
+
+			divided = append(divided, fields[i:end])
+		}
+		return divided
+	}
+
+	reducePeerStringSize := func(s string) string {
+		//Reduce size by removing userid
+		re := regexp.MustCompile("`.*?`\\s")
+		s = re.ReplaceAllString(s, "")
+
+		//Reduce size by replacing custom emoji (from 28 char to 1 char)
+		s = strings.ReplaceAll(s, "<:gundam:772467554160738355>", "🌎")
+		s = strings.ReplaceAll(s, "<:zaku:772467605008023563>", "🪐")
+
+		return s
 	}
 
 	//
-	// Create lobby peer list, for the second embed
+	// Implementation for the core function
 	//
-	var plazaPeers string
+	publish = func() {
+		//Stop any retry request since new request appeared
+		if discordLiveStatusRetryTimer != nil {
+			discordLiveStatusRetryTimer.Stop()
+			discordLiveStatusRetryTimer = nil
+		}
 
-	lobby := make(map[uint16]*lobbyPeers)
+		//
+		// Create battle peer list, for the third embed
+		//
+		battle := make(map[string]*battleUsers)
 
-	plazaPeerCount := 0
-	lobbyPeerCount := 0
+		battlePeerCount := 0
+		var battlePeersIDs string
+		var accumulatedBattlePeersString string
 
-	var accumulatedLobbyPeersString string
+		for _, u := range sharedData.GetMcsUsers() {
+			_, exists := battle[u.BattleCode]
+			if exists == false {
+				battle[u.BattleCode] = new(battleUsers)
 
-	lbs.Locked(func(lbs *Lbs) {
-		for _, u := range lbs.userPeers {
-
-			//Already in battle, hidden from lobby
-			if strings.Contains(battlePeersIDs, u.UserID) {
-				continue
+				locName, ok := gcpLocationName[u.McsRegion]
+				if !ok {
+					locName = "Default Server"
+				}
+				if u.McsRegion == "best" {
+					locName = "Best Server"
+				}
+				battle[u.BattleCode].RegionName = locName
+				accumulatedBattlePeersString += locName
 			}
 
-			if u.Lobby == nil {
-				plazaPeers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
-				accumulatedLobbyPeersString += plazaPeers
-				plazaPeerCount++
-			} else {
-				_, exists := lobby[u.Lobby.ID]
-				if exists == false {
-					lobby[u.Lobby.ID] = new(lobbyPeers)
-					lobby[u.Lobby.ID].Name = u.Lobby.Name
+			var peer string
+			switch u.Side {
+			case TeamRenpo:
+				peer = fmt.Sprintf("<:gundam:772467554160738355> `%s` %s\n", u.UserID, u.Name)
+				battle[u.BattleCode].RenpoPeers += peer
+			case TeamZeon:
+				peer = fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
+				battle[u.BattleCode].ZeonPeers += peer
+			}
+			accumulatedBattlePeersString += peer
 
-					locName, ok := gcpLocationName[u.Lobby.McsRegion]
-					if !ok {
-						locName = "Default Server"
-					}
-					if u.Lobby.McsRegion == "best" {
-						locName = "Best Server"
-					}
-					lobby[u.Lobby.ID].RegionName = locName
+			battlePeerCount++
+			battlePeersIDs += u.UserID
+		}
 
-					var comment string
-					if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
-						comment += "🔀"
-					}
-					if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
-						comment += "( 🇯🇵 vs 🇭🇰 )"
-					}
-					if strings.Contains(u.Lobby.Comment, "Private Room") {
-						comment += "🔒"
-					}
-					if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
-						comment += "⛔375"
-					}
-					if strings.Contains(u.Lobby.Comment, "3R") {
-						comment += "3️⃣"
-					}
+		//
+		// Create lobby peer list, for the second embed
+		//
+		var plazaPeers string
 
-					lobby[u.Lobby.ID].Comment = comment
+		lobby := make(map[uint16]*lobbyUsers)
+
+		plazaPeerCount := 0
+		lobbyPeerCount := 0
+
+		var accumulatedLobbyPeersString string
+
+		lbs.Locked(func(lbs *Lbs) {
+			for _, u := range lbs.userPeers {
+
+				//Already in battle, hidden from lobby
+				if strings.Contains(battlePeersIDs, u.UserID) {
+					continue
 				}
 
-				var readyColor string
-				if contains(u.Lobby.EntryUsers, u.UserID) {
-					readyColor = "🟢"
+				if u.Lobby == nil {
+					plazaPeers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
+					accumulatedLobbyPeersString += plazaPeers
+					plazaPeerCount++
 				} else {
-					readyColor = "🔴"
-				}
-				if u.Room != nil {
-					readyColor = "📢"
-				}
-				var peer string
-				switch u.Team {
-				case TeamRenpo:
-					peer = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
-					if u.Room == nil {
-						lobby[u.Lobby.ID].RenpoPeers += peer
-					} else {
-						lobby[u.Lobby.ID].RenpoRoomPeers += peer
-					}
-				case TeamZeon:
-					peer = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
-					if u.Room == nil {
-						lobby[u.Lobby.ID].ZeonPeers += peer
-					} else {
-						lobby[u.Lobby.ID].ZeonRoomPeers += peer
-					}
-				default:
-					peer = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
-					lobby[u.Lobby.ID].NoForcePeers += peer
-				}
-				accumulatedLobbyPeersString += peer
+					_, exists := lobby[u.Lobby.ID]
+					if exists == false {
+						lobby[u.Lobby.ID] = new(lobbyUsers)
+						lobby[u.Lobby.ID].Name = u.Lobby.Name
 
-				lobby[u.Lobby.ID].Count++
+						locName, ok := gcpLocationName[u.Lobby.McsRegion]
+						if !ok {
+							locName = "Default Server"
+						}
+						if u.Lobby.McsRegion == "best" {
+							locName = "Best Server"
+						}
+						lobby[u.Lobby.ID].RegionName = locName
+
+						var comment string
+						if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
+							comment += "🔀"
+						}
+						if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
+							comment += "( 🇯🇵 vs 🇭🇰 )"
+						}
+						if strings.Contains(u.Lobby.Comment, "Private Room") {
+							comment += "🔒"
+						}
+						if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
+							comment += "⛔375"
+						}
+						if strings.Contains(u.Lobby.Comment, "3R") {
+							comment += "3️⃣"
+						}
+
+						lobby[u.Lobby.ID].Comment = comment
+					}
+
+					var readyColor string
+					if contains(u.Lobby.EntryUsers, u.UserID) {
+						readyColor = "🟢"
+					} else {
+						readyColor = "🔴"
+					}
+					if u.Room != nil {
+						readyColor = "📢"
+					}
+					var peer string
+					switch u.Team {
+					case TeamRenpo:
+						peer = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+						if u.Room == nil {
+							lobby[u.Lobby.ID].RenpoPeers += peer
+						} else {
+							lobby[u.Lobby.ID].RenpoRoomPeers += peer
+						}
+					case TeamZeon:
+						peer = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+						if u.Room == nil {
+							lobby[u.Lobby.ID].ZeonPeers += peer
+						} else {
+							lobby[u.Lobby.ID].ZeonRoomPeers += peer
+						}
+					default:
+						peer = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
+						lobby[u.Lobby.ID].NoForcePeers += peer
+					}
+					accumulatedLobbyPeersString += peer
+
+					lobby[u.Lobby.ID].Count++
+				}
+				lobbyPeerCount++
 			}
-			lobbyPeerCount++
-		}
-	})
+		})
 
-	//
-	// Handle oversized string
-	//
-	embedAccumulatedLobbyStringLength := len(accumulatedLobbyPeersString)
-	logger.Info("Lobby string Size", zap.Int("length", embedAccumulatedLobbyStringLength))
-	if embedAccumulatedLobbyStringLength > 6000 {
-		plazaPeers = reducePeerStringSize(plazaPeers)
-
-		for _, l := range lobby {
-			l.RenpoPeers = reducePeerStringSize(l.RenpoPeers)
-			l.ZeonPeers = reducePeerStringSize(l.ZeonPeers)
-			l.RenpoRoomPeers = reducePeerStringSize(l.RenpoRoomPeers)
-			l.ZeonRoomPeers = reducePeerStringSize(l.ZeonRoomPeers)
-			l.NoForcePeers = reducePeerStringSize(l.NoForcePeers)
+		if lobby[2] != nil {
+			for i := 0; i < 4; i++ {
+				lobby[2].NoForcePeers += lobby[2].NoForcePeers
+				lobby[2].RenpoPeers += lobby[2].RenpoPeers
+			}
 		}
-		logger.Info("Lobby string size reduced!")
-	}
-	embedAccumulatedBattleStringLength := len(accumulatedBattlePeersString)
-	logger.Info("Battle string Size", zap.Int("length", embedAccumulatedBattleStringLength))
-	if embedAccumulatedBattleStringLength > 6000 {
+
+		//
+		// Handle oversized string
+		//
+		embedAccumulatedLobbyStringLength := len(accumulatedLobbyPeersString)
+		logger.Info("Lobby string Size", zap.Int("length", embedAccumulatedLobbyStringLength))
+		if embedAccumulatedLobbyStringLength > 6000 {
+			plazaPeers = reducePeerStringSize(plazaPeers)
+
+			for _, l := range lobby {
+				l.RenpoPeers = reducePeerStringSize(l.RenpoPeers)
+				l.ZeonPeers = reducePeerStringSize(l.ZeonPeers)
+				l.RenpoRoomPeers = reducePeerStringSize(l.RenpoRoomPeers)
+				l.ZeonRoomPeers = reducePeerStringSize(l.ZeonRoomPeers)
+				l.NoForcePeers = reducePeerStringSize(l.NoForcePeers)
+			}
+			logger.Info("Lobby string size reduced!")
+		}
+		embedAccumulatedBattleStringLength := len(accumulatedBattlePeersString)
+		logger.Info("Battle string Size", zap.Int("length", embedAccumulatedBattleStringLength))
+		if embedAccumulatedBattleStringLength > 6000 {
+			for _, b := range battle {
+				b.RenpoPeers = reducePeerStringSize(b.RenpoPeers)
+				b.ZeonPeers = reducePeerStringSize(b.ZeonPeers)
+			}
+			logger.Info("Battle string size reduced!")
+		}
+
+		//
+		// Start to create JSON payload
+		//
+		payload := new(statusPayload)
+		payload.BotName = "Live Status"
+
+		//
+		//1st Embed, online count
+		//
+		payload.Embed = append(payload.Embed, &discordEmbed{
+			Title:     fmt.Sprintf("**同時接続数 %d 人 **", lobbyPeerCount+battlePeerCount),
+			Color:     52224,
+			Footer:    &discordEmbedFooter{Text: "🕒"},
+			Timestamp: fmt.Sprintf(time.Now().UTC().Format("2006-01-02T15:04:05.000Z")),
+		})
+
+		//
+		//2nd Embed, lobby count
+		//
+
+		//1st Field is always Plaza
+		var lobbyFields []*discordEmbedField
+		if plazaPeerCount > 0 {
+			for i, v := range splitEmbedFieldValues(plazaPeers) {
+				name := "⠀"
+				if i == 0 {
+					name = fmt.Sprintf("**Plaza － %d 人**", plazaPeerCount)
+				}
+
+				lobbyFields = append(lobbyFields, &discordEmbedField{
+					Name:  name,
+					Value: v,
+				})
+			}
+		}
+
+		//Following Fields would be all lobbies
+		//Use sortedKeys to fix the ordering
+		for _, i := range sortedKeys(lobby) {
+			l := lobby[i]
+
+			value := addBlankIfRequired(l.RenpoPeers+l.ZeonPeers) + addBlankIfRequired(l.RenpoRoomPeers+l.ZeonRoomPeers) + addBlankIfRequired(l.NoForcePeers)
+
+			for i, v := range splitEmbedFieldValues(value) {
+				name := "⠀"
+				if i == 0 {
+					name = fmt.Sprintf("**%s － %d 人\n%s %s**", l.Name, l.Count, l.RegionName, l.Comment)
+				}
+
+				lobbyFields = append(lobbyFields, &discordEmbedField{
+					Name:  name,
+					Value: v,
+				})
+			}
+
+		}
+		for i, fields := range splitEmbedFields(lobbyFields) {
+			description := ""
+			if i == 0 {
+				description = fmt.Sprintf("🌐 **待機中 %d 人**", lobbyPeerCount)
+			}
+			payload.Embed = append(payload.Embed, &discordEmbed{
+				Description: description,
+				Color:       24041,
+				Fields:      fields,
+			})
+		}
+
+		//
+		//3rd Embed, battle count
+		//
+		var battleFields []*discordEmbedField
 		for _, b := range battle {
-			b.RenpoPeers = reducePeerStringSize(b.RenpoPeers)
-			b.ZeonPeers = reducePeerStringSize(b.ZeonPeers)
-		}
-		logger.Info("Battle string size reduced!")
-	}
 
-	//
-	// Start to create JSON payload
-	//
-	payload := new(statusPayload)
-	payload.BotName = "Live Status"
+			value := addBlankIfRequired(b.RenpoPeers + b.ZeonPeers)
 
-	//
-	//1st Embed, online count
-	//
-	payload.Embed = append(payload.Embed, &discordEmbed{
-		Title:     fmt.Sprintf("**同時接続数 %d 人 **", lobbyPeerCount+battlePeerCount),
-		Color:     52224,
-		Footer:    &discordEmbedFooter{Text: "🕒"},
-		Timestamp: fmt.Sprintf(time.Now().UTC().Format("2006-01-02T15:04:05.000Z")),
-	})
+			for i, v := range splitEmbedFieldValues(value) {
+				name := "⠀"
+				if i == 0 {
+					name = b.RegionName
+				}
 
-	//
-	//2nd Embed, lobby count
-	//
-
-	//1st Field is always Plaza
-	var lobbyFields []*discordEmbedField
-	if plazaPeerCount > 0 {
-		for i, v := range splitEmbedFieldValues(plazaPeers) {
-			name := "⠀"
-			if i == 0 {
-				name = fmt.Sprintf("**Plaza － %d 人**", plazaPeerCount)
+				battleFields = append(battleFields, &discordEmbedField{
+					Name:  name,
+					Value: v,
+				})
 			}
-
-			lobbyFields = append(lobbyFields, &discordEmbedField{
-				Name:  name,
-				Value: v,
-			})
 		}
-	}
-
-	//Following Fields would be all lobbies
-	//Use sortedKeys to fix the ordering
-	for _, i := range sortedKeys(lobby) {
-		l := lobby[i]
-
-		value := addBlankIfRequired(l.RenpoPeers+l.ZeonPeers) + addBlankIfRequired(l.RenpoRoomPeers+l.ZeonRoomPeers) + addBlankIfRequired(l.NoForcePeers)
-
-		for i, v := range splitEmbedFieldValues(value) {
-			name := "⠀"
+		for i, fields := range splitEmbedFields(battleFields) {
+			description := ""
 			if i == 0 {
-				name = fmt.Sprintf("**%s － %d 人\n%s %s**", l.Name, l.Count, l.RegionName, l.Comment)
+				description = fmt.Sprintf("💥 **戦闘中 %d 人**", battlePeerCount)
 			}
-
-			lobbyFields = append(lobbyFields, &discordEmbedField{
-				Name:  name,
-				Value: v,
+			payload.Embed = append(payload.Embed, &discordEmbed{
+				Description: description,
+				Color:       13179394,
+				Fields:      fields,
 			})
 		}
 
-	}
-	for i, fields := range splitEmbedFields(lobbyFields) {
-		description := ""
-		if i == 0 {
-			description = fmt.Sprintf("🌐 **待機中 %d 人**", lobbyPeerCount)
-		}
-		payload.Embed = append(payload.Embed, &discordEmbed{
-			Description: description,
-			Color:       24041,
-			Fields:      fields,
-		})
-	}
+		//
+		// Create the json
+		//
+		var jsonData []byte
+		jsonData, err := json.Marshal(payload)
 
-	//
-	//3rd Embed, battle count
-	//
-	var battleFields []*discordEmbedField
-	for _, b := range battle {
-
-		value := addBlankIfRequired(b.RenpoPeers + b.ZeonPeers)
-
-		for i, v := range splitEmbedFieldValues(value) {
-			name := "⠀"
-			if i == 0 {
-				name = b.RegionName
-			}
-
-			battleFields = append(battleFields, &discordEmbedField{
-				Name:  name,
-				Value: v,
-			})
-		}
-	}
-	for i, fields := range splitEmbedFields(battleFields) {
-		description := ""
-		if i == 0 {
-			description = fmt.Sprintf("💥 **戦闘中 %d 人**", battlePeerCount)
-		}
-		payload.Embed = append(payload.Embed, &discordEmbed{
-			Description: description,
-			Color:       13179394,
-			Fields:      fields,
-		})
-	}
-
-	//
-	// Create the json
-	//
-	var jsonData []byte
-	jsonData, err := json.Marshal(payload)
-
-	if err != nil {
-		logger.Error("Failed to create Discord JSON", zap.Error(err))
-		return
-	}
-	jsonString := string(jsonData)
-	logger.Info(jsonString, zap.Int("length", len(jsonString)))
-
-	send(jsonData)
-
-}
-
-//
-// Send to Discord
-//
-func send(jsonData []byte) {
-
-	req, err := http.NewRequest("PATCH", conf.DiscordWebhookURL, bytes.NewBuffer(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		logger.Error("Failed to publish to Discord", zap.Error(err))
-		return
-	}
-	defer resp.Body.Close()
-
-	logger.Info("Discord Webhook sent", zap.String("Status", resp.Status))
-	if resp.Status == "400 Bad Request" {
-		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			logger.Error("Failed to read response body", zap.Error(err))
+			logger.Error("Failed to create Discord JSON", zap.Error(err))
 			return
 		}
-		logger.Error("Failed to create Discord JSON", zap.String("Error:", string(body)))
-	} else if resp.Status == "429 Too Many Requests" {
+		jsonString := string(jsonData)
+		logger.Info(jsonString, zap.Int("length", len(jsonString)))
 
-		resetepochTime := resp.Header.Get("x-ratelimit-reset")
-		sec, _ := strconv.ParseInt(resetepochTime, 10, 64)
-		logger.Info("Rate limit", zap.Int64("x-ratelimit-reset", sec))
+		//
+		// Send to Discord
+		//
+		var send func(jsonData []byte)
+		send = func(jsonData []byte) {
 
-		retryTimer = time.AfterFunc(time.Unix(sec, 0).Sub(time.Now()), func() {
-			logger.Info("Retrying last request", zap.Int64("epoch", time.Now().Unix()))
-			send(jsonData)
-		})
+			req, err := http.NewRequest("PATCH", conf.DiscordWebhookURL, bytes.NewBuffer(jsonData))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				logger.Error("Failed to publish to Discord", zap.Error(err))
+				return
+			}
+			defer resp.Body.Close()
+
+			logger.Info("Discord Webhook sent", zap.String("Status", resp.Status))
+			if resp.Status == "400 Bad Request" {
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					logger.Error("Failed to read response body", zap.Error(err))
+					return
+				}
+				logger.Error("Failed to create Discord JSON", zap.String("Error:", string(body)))
+			} else if resp.Status == "429 Too Many Requests" {
+
+				resetepochTime := resp.Header.Get("x-ratelimit-reset")
+				sec, _ := strconv.ParseInt(resetepochTime, 10, 64)
+				logger.Info("Rate limit", zap.Int64("x-ratelimit-reset", sec))
+
+				discordLiveStatusRetryTimer = time.AfterFunc(time.Unix(sec, 0).Sub(time.Now()), func() {
+					logger.Info("Retrying last request", zap.Int64("epoch", time.Now().Unix()))
+					send(jsonData)
+				})
+			}
+
+		}
+
+		send(jsonData)
+
 	}
 
 }

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -312,13 +312,6 @@ func publish(lbs *Lbs) {
 		}
 	})
 
-	if lobby[2] != nil {
-		for i := 0; i < 4; i++ {
-			lobby[2].NoForcePeers += lobby[2].NoForcePeers
-			lobby[2].RenpoPeers += lobby[2].RenpoPeers
-		}
-	}
-
 	//
 	// Handle oversized string
 	//

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -91,7 +91,7 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 					locName = "Default Server"
 				}
 				if u.McsRegion == "best" {
-					locName = "Best Server [Auto Detection]"
+					locName = "Best Server"
 				}
 				battle[u.BattleCode].RegionName = locName
 			}
@@ -143,7 +143,7 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 						locName = "Default Server"
 					}
 					if u.Lobby.McsRegion == "best" {
-						locName = "Best Server [Auto Detection]"
+						locName = "Best Server"
 					}
 					lobby[u.Lobby.ID].RegionName = locName
 

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -197,7 +197,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 		//
 		// Create lobby user list, for the second embed
 		//
-		var plazaUsers string
+		var plazaUsersBuf bytes.Buffer
 
 		lobby := make(map[uint16]*lobbyUsers)
 
@@ -213,7 +213,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 				}
 
 				if u.Lobby == nil {
-					plazaUsers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
+					plazaUsersBuf.WriteString(fmt.Sprintf("`%s` %s\n", u.UserID, u.Name))
 					plazaUserCount++
 				} else {
 					_, exists := lobby[u.Lobby.ID]
@@ -318,7 +318,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 		//1st Field is always Plaza
 		var lobbyFields []*discordEmbedField
 		if plazaUserCount > 0 {
-			for i, v := range splitEmbedFieldValues(plazaUsers) {
+			for i, v := range splitEmbedFieldValues(plazaUsersBuf.String()) {
 				name := "⠀"
 				if i == 0 {
 					name = fmt.Sprintf("**Plaza － %d 人**", plazaUserCount)

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -33,7 +33,7 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 
 	//insert Braille Pattern Blank to create newline at ending
 	addBlankIfRequired := func(s string) string {
-		if strings.HasSuffix(s, "\n") {
+		if len(s) > 0 {
 			return s + "⠀\n"
 		}
 		return s
@@ -176,12 +176,22 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 				if u.Room != nil {
 					readyColor = "📢"
 				}
-
+				var peer string
 				switch u.Team {
 				case TeamRenpo:
-					lobby[u.Lobby.ID].RenpoPeers += fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+					peer = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+					if u.Room == nil {
+						lobby[u.Lobby.ID].RenpoPeers += peer
+					} else {
+						lobby[u.Lobby.ID].RenpoRoomPeers += peer
+					}
 				case TeamZeon:
-					lobby[u.Lobby.ID].ZeonPeers += fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+					peer = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+					if u.Room == nil {
+						lobby[u.Lobby.ID].ZeonPeers += peer
+					} else {
+						lobby[u.Lobby.ID].ZeonRoomPeers += peer
+					}
 				default:
 					lobby[u.Lobby.ID].NoForcePeers += fmt.Sprintf(":grey_question::black_circle: `%s` %s\n", u.UserID, u.Name)
 				}

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -77,21 +77,21 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 	}
 
 	type lobbyUsers struct {
-		Count          int
-		Name           string
-		RegionName     string
-		Comment        string
-		RenpoUsers     string
-		ZeonUsers      string
-		RenpoRoomUsers string
-		ZeonRoomUsers  string
-		NoForceUsers   string
+		Count                int
+		Name                 string
+		RegionName           string
+		Comment              string
+		RenpoUsersString     string
+		ZeonUsersString      string
+		RenpoRoomUsersString string
+		ZeonRoomUsersString  string
+		NoForceUsersString   string
 	}
 
 	type battleUsers struct {
-		RegionName string
-		RenpoUsers string
-		ZeonUsers  string
+		RegionName       string
+		RenpoUsersString string
+		ZeonUsersString  string
 	}
 
 	//
@@ -218,10 +218,10 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 			switch u.Side {
 			case TeamRenpo:
 				user = fmt.Sprintf("<:gundam:772467554160738355> `%s` %s\n", u.UserID, u.Name)
-				battle[u.BattleCode].RenpoUsers += user
+				battle[u.BattleCode].RenpoUsersString += user
 			case TeamZeon:
 				user = fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
-				battle[u.BattleCode].ZeonUsers += user
+				battle[u.BattleCode].ZeonUsersString += user
 			}
 			accumulatedBattleEmbedStringLength += len(user)
 
@@ -303,20 +303,20 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					case TeamRenpo:
 						user = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
 						if u.Room == nil {
-							lobby[u.Lobby.ID].RenpoUsers += user
+							lobby[u.Lobby.ID].RenpoUsersString += user
 						} else {
-							lobby[u.Lobby.ID].RenpoRoomUsers += user
+							lobby[u.Lobby.ID].RenpoRoomUsersString += user
 						}
 					case TeamZeon:
 						user = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
 						if u.Room == nil {
-							lobby[u.Lobby.ID].ZeonUsers += user
+							lobby[u.Lobby.ID].ZeonUsersString += user
 						} else {
-							lobby[u.Lobby.ID].ZeonRoomUsers += user
+							lobby[u.Lobby.ID].ZeonRoomUsersString += user
 						}
 					default:
 						user = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
-						lobby[u.Lobby.ID].NoForceUsers += user
+						lobby[u.Lobby.ID].NoForceUsersString += user
 					}
 					accumulatedLobbyEmbedStringLength += len(user)
 
@@ -400,7 +400,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		for _, i := range sortedKeys(lobby) {
 			l := lobby[i]
 
-			value := addBlankIfRequired(l.RenpoUsers+l.ZeonUsers) + addBlankIfRequired(l.RenpoRoomUsers+l.ZeonRoomUsers) + addBlankIfRequired(l.NoForceUsers)
+			value := addBlankIfRequired(l.RenpoUsersString+l.ZeonUsersString) + addBlankIfRequired(l.RenpoRoomUsersString+l.ZeonRoomUsersString) + addBlankIfRequired(l.NoForceUsersString)
 
 			for i, v := range splitEmbedFieldValues(value) {
 				name := "⠀"
@@ -433,7 +433,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		var battleFields []*discordEmbedField
 		for _, b := range battle {
 
-			value := addBlankIfRequired(b.RenpoUsers + b.ZeonUsers)
+			value := addBlankIfRequired(b.RenpoUsersString + b.ZeonUsersString)
 
 			for i, v := range splitEmbedFieldValues(value) {
 				name := "⠀"

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -195,6 +195,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		existingBattleUserIDs := make(map[string]bool)
 
 		battleUserCount := 0
+		accumulatedEmbedStringLength := 0
 
 		for _, u := range sharedData.GetMcsUsers() {
 			_, exists := battle[u.BattleCode]
@@ -209,6 +210,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					locName = "Best Server"
 				}
 				battle[u.BattleCode].RegionName = locName
+				accumulatedEmbedStringLength += len(locName)
 			}
 
 			var user string
@@ -220,6 +222,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 				user = fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
 				battle[u.BattleCode].ZeonUsersString += user
 			}
+			accumulatedEmbedStringLength += len(user)
 
 			battleUserCount++
 			existingBattleUserIDs[u.UserID] = true
@@ -245,6 +248,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 
 				if u.Lobby == nil {
 					plazaUsers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
+					accumulatedEmbedStringLength += len(plazaUsers)
 					plazaUserCount++
 				} else {
 					_, exists := lobby[u.Lobby.ID]
@@ -279,6 +283,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 						}
 
 						lobby[u.Lobby.ID].Comment = comment
+						accumulatedEmbedStringLength += len(comment)
 					}
 
 					var readyColor string
@@ -310,6 +315,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 						user = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
 						lobby[u.Lobby.ID].NoForceUsersString += user
 					}
+					accumulatedEmbedStringLength += len(user)
 
 					lobby[u.Lobby.ID].Count++
 				}
@@ -350,6 +356,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					Name:  name,
 					Value: v,
 				})
+				accumulatedEmbedStringLength += len(name) + len(v)
 			}
 		}
 
@@ -370,6 +377,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					Name:  name,
 					Value: v,
 				})
+				accumulatedEmbedStringLength += len(name) + len(v)
 			}
 
 		}
@@ -383,6 +391,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 				Color:       24041,
 				Fields:      fields,
 			})
+			accumulatedEmbedStringLength += len(description)
 		}
 
 		//
@@ -403,6 +412,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					Name:  name,
 					Value: v,
 				})
+				accumulatedEmbedStringLength += len(name) + len(v)
 			}
 		}
 		for i, fields := range splitEmbedFields(battleFields) {
@@ -415,6 +425,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 				Color:       13179394,
 				Fields:      fields,
 			})
+			accumulatedEmbedStringLength += len(description)
 		}
 
 		//
@@ -431,7 +442,7 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 		}
 
 		//embed structure must not exceed 6000 characters
-		if buffer.Len() > 6000 {
+		if accumulatedEmbedStringLength > 6000 {
 			originalSize := buffer.Len()
 
 			start := time.Now()

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -164,7 +164,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 		existingBattleUserIDs := make(map[string]bool)
 
 		battleUserCount := 0
-		accumulatedEmbedStringLength := 0
 
 		for _, u := range sharedData.GetMcsUsers() {
 			_, exists := battle[u.BattleCode]
@@ -179,7 +178,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 					locName = "Best Server"
 				}
 				battle[u.BattleCode].RegionName = locName
-				accumulatedEmbedStringLength += len(locName)
 			}
 
 			var user string
@@ -191,7 +189,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 				user = fmt.Sprintf("<:zaku:772467605008023563> `%s` %s\n", u.UserID, u.Name)
 				battle[u.BattleCode].ZeonUsersBuf.WriteString(user)
 			}
-			accumulatedEmbedStringLength += len(user)
 
 			battleUserCount++
 			existingBattleUserIDs[u.UserID] = true
@@ -217,7 +214,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 
 				if u.Lobby == nil {
 					plazaUsers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
-					accumulatedEmbedStringLength += len(plazaUsers)
 					plazaUserCount++
 				} else {
 					_, exists := lobby[u.Lobby.ID]
@@ -259,7 +255,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 						}
 
 						lobby[u.Lobby.ID].Comment = commentBuf.String()
-						accumulatedEmbedStringLength += len(lobby[u.Lobby.ID].Comment)
 					}
 
 					var readyColor string
@@ -291,7 +286,6 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 						user = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
 						lobby[u.Lobby.ID].NoForceUsersBuf.WriteString(user)
 					}
-					accumulatedEmbedStringLength += len(user)
 
 					lobby[u.Lobby.ID].Count++
 				}
@@ -303,7 +297,8 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 		// Start to create JSON payload
 		//
 		payload := new(statusPayload)
-		payload.BotName = "Live Status"
+		// payload.BotName = "Live Status"
+		accumulatedEmbedStringLength := 0
 
 		//
 		//1st Embed, online count
@@ -314,6 +309,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 			Footer:    &discordEmbedFooter{Text: "🕒"},
 			Timestamp: fmt.Sprintf(time.Now().UTC().Format("2006-01-02T15:04:05.000Z")),
 		})
+		accumulatedEmbedStringLength += len(payload.Embed[0].Title) + len(payload.Embed[0].Footer.Text)
 
 		//
 		//2nd Embed, lobby count

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -468,7 +468,8 @@ func (lbs *Lbs) PublishLiveStatusToDiscord() {
 					logger.Error("Failed to read response body", zap.Error(err))
 					return
 				}
-				logger.Error("Failed to create Discord JSON", zap.String("Error:", string(body)))
+				logger.Error("Discord 400 Bad Request", zap.String("Error:", string(body)))
+
 			} else if resp.StatusCode == http.StatusTooManyRequests {
 
 				resetepochTime := resp.Header.Get("x-ratelimit-reset")

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -34,9 +34,9 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 	}
 
 	type discordEmbedField struct {
-		Name   string `json:"name,omitempty"`
-		Value  string `json:"value,omitempty"`
-		Inline bool   `json:"inline,omitempty"`
+		Name  string `json:"name,omitempty"`
+		Value string `json:"value,omitempty"`
+		// Inline bool   `json:"inline,omitempty"`
 	}
 
 	type discordEmbed struct {
@@ -49,8 +49,8 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 	}
 
 	type statusPayload struct {
-		Embed   []*discordEmbed `json:"embeds"`
-		BotName string          `json:"username"`
+		Embed []*discordEmbed `json:"embeds"`
+		// BotName string          `json:"username"`
 	}
 
 	type lobbyUsers struct {

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -135,13 +135,8 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 		return divided
 	}
 
-	reduceJSONStringSize := func(s string) string {
-		//Reduce size by using standard emoji
-		replacer := strings.NewReplacer("<:gundam:772467554160738355>", "🌎", "<:zaku:772467605008023563>", "🪐")
-		s = replacer.Replace(s)
-
-		return s
-	}
+	//Reduce size by using standard emoji
+	emojiReplacer := strings.NewReplacer("<:gundam:772467554160738355>", "🌎", "<:zaku:772467605008023563>", "🪐")
 
 	//
 	// Implementation for the core function
@@ -436,7 +431,7 @@ func (lbs *Lbs) publishLiveStatusToDiscordLoop() {
 			originalSize := buffer.Len()
 
 			start := time.Now()
-			jsonString := reduceJSONStringSize(buffer.String())
+			jsonString := emojiReplacer.Replace(buffer.String())
 			buffer.Reset()
 			buffer.Write([]byte(jsonString))
 			elapsed := time.Since(start)

--- a/gdxsv/lbs_discord.go
+++ b/gdxsv/lbs_discord.go
@@ -212,87 +212,89 @@ func (lbs *Lbs) PublishStatusToDiscord() {
 
 		var accumulatedLobbyPeersString string
 
-		for _, u := range lbs.userPeers {
+		lbs.Locked(func(lbs *Lbs) {
+			for _, u := range lbs.userPeers {
 
-			//Already in battle, hidden from lobby
-			if strings.Contains(battlePeersIDs, u.UserID) {
-				continue
-			}
-
-			if u.Lobby == nil {
-				plazaPeers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
-				accumulatedLobbyPeersString += plazaPeers
-				plazaPeerCount++
-			} else {
-				_, exists := lobby[u.Lobby.ID]
-				if exists == false {
-					lobby[u.Lobby.ID] = new(LobbyPeers)
-					lobby[u.Lobby.ID].Name = u.Lobby.Name
-
-					locName, ok := gcpLocationName[u.Lobby.McsRegion]
-					if !ok {
-						locName = "Default Server"
-					}
-					if u.Lobby.McsRegion == "best" {
-						locName = "Best Server"
-					}
-					lobby[u.Lobby.ID].RegionName = locName
-
-					var comment string
-					if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
-						comment += "🔀"
-					}
-					if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
-						comment += "( 🇯🇵 vs 🇭🇰 )"
-					}
-					if strings.Contains(u.Lobby.Comment, "Private Room") {
-						comment += "🔒"
-					}
-					if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
-						comment += "⛔375"
-					}
-					if strings.Contains(u.Lobby.Comment, "3R") {
-						comment += "3️⃣"
-					}
-
-					lobby[u.Lobby.ID].Comment = comment
+				//Already in battle, hidden from lobby
+				if strings.Contains(battlePeersIDs, u.UserID) {
+					continue
 				}
 
-				var readyColor string
-				if contains(u.Lobby.EntryUsers, u.UserID) {
-					readyColor = "🟢"
+				if u.Lobby == nil {
+					plazaPeers += fmt.Sprintf("`%s` %s\n", u.UserID, u.Name)
+					accumulatedLobbyPeersString += plazaPeers
+					plazaPeerCount++
 				} else {
-					readyColor = "🔴"
-				}
-				if u.Room != nil {
-					readyColor = "📢"
-				}
-				var peer string
-				switch u.Team {
-				case TeamRenpo:
-					peer = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
-					if u.Room == nil {
-						lobby[u.Lobby.ID].RenpoPeers += peer
-					} else {
-						lobby[u.Lobby.ID].RenpoRoomPeers += peer
-					}
-				case TeamZeon:
-					peer = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
-					if u.Room == nil {
-						lobby[u.Lobby.ID].ZeonPeers += peer
-					} else {
-						lobby[u.Lobby.ID].ZeonRoomPeers += peer
-					}
-				default:
-					peer = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
-					lobby[u.Lobby.ID].NoForcePeers += peer
-				}
-				accumulatedLobbyPeersString += peer
+					_, exists := lobby[u.Lobby.ID]
+					if exists == false {
+						lobby[u.Lobby.ID] = new(LobbyPeers)
+						lobby[u.Lobby.ID].Name = u.Lobby.Name
 
-				lobby[u.Lobby.ID].Count++
+						locName, ok := gcpLocationName[u.Lobby.McsRegion]
+						if !ok {
+							locName = "Default Server"
+						}
+						if u.Lobby.McsRegion == "best" {
+							locName = "Best Server"
+						}
+						lobby[u.Lobby.ID].RegionName = locName
+
+						var comment string
+						if strings.Contains(u.Lobby.Comment, "TeamShuffle") {
+							comment += "🔀"
+						}
+						if strings.Contains(u.Lobby.Comment, "For JP vs HK") {
+							comment += "( 🇯🇵 vs 🇭🇰 )"
+						}
+						if strings.Contains(u.Lobby.Comment, "Private Room") {
+							comment += "🔒"
+						}
+						if strings.Contains(u.Lobby.Comment, "No 375 Cost MS") {
+							comment += "⛔375"
+						}
+						if strings.Contains(u.Lobby.Comment, "3R") {
+							comment += "3️⃣"
+						}
+
+						lobby[u.Lobby.ID].Comment = comment
+					}
+
+					var readyColor string
+					if contains(u.Lobby.EntryUsers, u.UserID) {
+						readyColor = "🟢"
+					} else {
+						readyColor = "🔴"
+					}
+					if u.Room != nil {
+						readyColor = "📢"
+					}
+					var peer string
+					switch u.Team {
+					case TeamRenpo:
+						peer = fmt.Sprintf("<:gundam:772467554160738355>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+						if u.Room == nil {
+							lobby[u.Lobby.ID].RenpoPeers += peer
+						} else {
+							lobby[u.Lobby.ID].RenpoRoomPeers += peer
+						}
+					case TeamZeon:
+						peer = fmt.Sprintf("<:zaku:772467605008023563>%s `%s` %s\n", readyColor, u.UserID, u.Name)
+						if u.Room == nil {
+							lobby[u.Lobby.ID].ZeonPeers += peer
+						} else {
+							lobby[u.Lobby.ID].ZeonRoomPeers += peer
+						}
+					default:
+						peer = fmt.Sprintf("❔⚫ `%s` %s\n", u.UserID, u.Name)
+						lobby[u.Lobby.ID].NoForcePeers += peer
+					}
+					accumulatedLobbyPeersString += peer
+
+					lobby[u.Lobby.ID].Count++
+				}
+				lobbyPeerCount++
 			}
-			lobbyPeerCount++
-		}
+		})
 
 		//
 		// Handle oversized string

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -661,7 +661,7 @@ var _ = register(lbsServerMoney, func(p *LbsPeer, m *LbsMessage) {
 
 var _ = register(lbsStartLobby, func(p *LbsPeer, m *LbsMessage) {
 	p.SendMessage(NewServerAnswer(m))
-	go p.app.PublishStatusToDiscord()
+	p.app.PublishStatusToDiscord()
 })
 
 var _ = register(lbsInvitationTag, func(p *LbsPeer, m *LbsMessage) {

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -661,7 +661,7 @@ var _ = register(lbsServerMoney, func(p *LbsPeer, m *LbsMessage) {
 
 var _ = register(lbsStartLobby, func(p *LbsPeer, m *LbsMessage) {
 	p.SendMessage(NewServerAnswer(m))
-	p.app.PublishStatusToDiscord()
+	go p.app.PublishStatusToDiscord()
 })
 
 var _ = register(lbsInvitationTag, func(p *LbsPeer, m *LbsMessage) {

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -661,6 +661,7 @@ var _ = register(lbsServerMoney, func(p *LbsPeer, m *LbsMessage) {
 
 var _ = register(lbsStartLobby, func(p *LbsPeer, m *LbsMessage) {
 	p.SendMessage(NewServerAnswer(m))
+	p.app.PublishStatusToDiscord()
 })
 
 var _ = register(lbsInvitationTag, func(p *LbsPeer, m *LbsMessage) {

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -661,7 +661,7 @@ var _ = register(lbsServerMoney, func(p *LbsPeer, m *LbsMessage) {
 
 var _ = register(lbsStartLobby, func(p *LbsPeer, m *LbsMessage) {
 	p.SendMessage(NewServerAnswer(m))
-	p.app.PublishStatusToDiscord()
+	p.app.PublishLiveStatusToDiscord()
 })
 
 var _ = register(lbsInvitationTag, func(p *LbsPeer, m *LbsMessage) {

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -661,7 +661,7 @@ var _ = register(lbsServerMoney, func(p *LbsPeer, m *LbsMessage) {
 
 var _ = register(lbsStartLobby, func(p *LbsPeer, m *LbsMessage) {
 	p.SendMessage(NewServerAnswer(m))
-	p.app.PublishLiveStatusToDiscord()
+	discordLiveStatusUpdateAvailable = true
 })
 
 var _ = register(lbsInvitationTag, func(p *LbsPeer, m *LbsMessage) {

--- a/gdxsv/main.go
+++ b/gdxsv/main.go
@@ -47,17 +47,17 @@ var (
 )
 
 type Config struct {
-	LobbyAddr         string `env:"GDXSV_LOBBY_ADDR" envDefault:"localhost:3333"`
-	LobbyPublicAddr   string `env:"GDXSV_LOBBY_PUBLIC_ADDR" envDefault:"127.0.0.1:3333"`
-	LobbyHttpAddr     string `env:"GDXSV_LOBBY_HTTP_ADDR" envDefault:":3380"`
-	BattleAddr        string `env:"GDXSV_BATTLE_ADDR" envDefault:"localhost:3334"`
-	BattlePublicAddr  string `env:"GDXSV_BATTLE_PUBLIC_ADDR" envDefault:"127.0.0.1:3334"`
-	BattleRegion      string `env:"GDXSV_BATTLE_REGION" envDefault:""`
-	BattleLogPath     string `env:"GDXSV_BATTLE_LOG_PATH" envDefault:"./battlelog"`
-	McsFuncKey        string `env:"GDXSV_MCSFUNC_KEY" envDefault:""`
-	McsFuncURL        string `env:"GDXSV_MCSFUNC_URL" envDefault:""`
-	DiscordWebhookURL string `env:"GDXSV_DISCORD_WEBHOOK_URL" envDefault:""`
-	DBName            string `env:"GDXSV_DB_NAME" envDefault:"gdxsv.db"`
+	LobbyAddr                   string `env:"GDXSV_LOBBY_ADDR" envDefault:"localhost:3333"`
+	LobbyPublicAddr             string `env:"GDXSV_LOBBY_PUBLIC_ADDR" envDefault:"127.0.0.1:3333"`
+	LobbyHttpAddr               string `env:"GDXSV_LOBBY_HTTP_ADDR" envDefault:":3380"`
+	BattleAddr                  string `env:"GDXSV_BATTLE_ADDR" envDefault:"localhost:3334"`
+	BattlePublicAddr            string `env:"GDXSV_BATTLE_PUBLIC_ADDR" envDefault:"127.0.0.1:3334"`
+	BattleRegion                string `env:"GDXSV_BATTLE_REGION" envDefault:""`
+	BattleLogPath               string `env:"GDXSV_BATTLE_LOG_PATH" envDefault:"./battlelog"`
+	McsFuncKey                  string `env:"GDXSV_MCSFUNC_KEY" envDefault:""`
+	McsFuncURL                  string `env:"GDXSV_MCSFUNC_URL" envDefault:""`
+	DiscordLiveStatusWebhookURL string `env:"GDXSV_DISCORD_LIVESTATUS_WEBHOOK_URL" envDefault:""`
+	DBName                      string `env:"GDXSV_DB_NAME" envDefault:"gdxsv.db"`
 }
 
 func printHeader() {

--- a/gdxsv/main.go
+++ b/gdxsv/main.go
@@ -47,16 +47,17 @@ var (
 )
 
 type Config struct {
-	LobbyAddr        string `env:"GDXSV_LOBBY_ADDR" envDefault:"localhost:3333"`
-	LobbyPublicAddr  string `env:"GDXSV_LOBBY_PUBLIC_ADDR" envDefault:"127.0.0.1:3333"`
-	LobbyHttpAddr    string `env:"GDXSV_LOBBY_HTTP_ADDR" envDefault:":3380"`
-	BattleAddr       string `env:"GDXSV_BATTLE_ADDR" envDefault:"localhost:3334"`
-	BattlePublicAddr string `env:"GDXSV_BATTLE_PUBLIC_ADDR" envDefault:"127.0.0.1:3334"`
-	BattleRegion     string `env:"GDXSV_BATTLE_REGION" envDefault:""`
-	BattleLogPath    string `env:"GDXSV_BATTLE_LOG_PATH" envDefault:"./battlelog"`
-	McsFuncKey       string `env:"GDXSV_MCSFUNC_KEY" envDefault:""`
-	McsFuncURL       string `env:"GDXSV_MCSFUNC_URL" envDefault:""`
-	DBName           string `env:"GDXSV_DB_NAME" envDefault:"gdxsv.db"`
+	LobbyAddr         string `env:"GDXSV_LOBBY_ADDR" envDefault:"localhost:3333"`
+	LobbyPublicAddr   string `env:"GDXSV_LOBBY_PUBLIC_ADDR" envDefault:"127.0.0.1:3333"`
+	LobbyHttpAddr     string `env:"GDXSV_LOBBY_HTTP_ADDR" envDefault:":3380"`
+	BattleAddr        string `env:"GDXSV_BATTLE_ADDR" envDefault:"localhost:3334"`
+	BattlePublicAddr  string `env:"GDXSV_BATTLE_PUBLIC_ADDR" envDefault:"127.0.0.1:3334"`
+	BattleRegion      string `env:"GDXSV_BATTLE_REGION" envDefault:""`
+	BattleLogPath     string `env:"GDXSV_BATTLE_LOG_PATH" envDefault:"./battlelog"`
+	McsFuncKey        string `env:"GDXSV_MCSFUNC_KEY" envDefault:""`
+	McsFuncURL        string `env:"GDXSV_MCSFUNC_URL" envDefault:""`
+	DiscordWebhookURL string `env:"GDXSV_DISCORD_WEBHOOK_URL" envDefault:""`
+	DBName            string `env:"GDXSV_DB_NAME" envDefault:"gdxsv.db"`
 }
 
 func printHeader() {


### PR DESCRIPTION
![Nov-03-2020 02-19-43](https://user-images.githubusercontent.com/602245/97904196-1b3b8300-1d7b-11eb-8931-ac6abc467221.gif)

Whenever the below functions/events are triggered:
`lbsStartLobby`
`BroadcastLobbyUserCount`
`BroadcastLobbyMatchEntryUserCount`
`BroadcastRoomState`

it will publish the latest server status to Discord.

What I didn't do:
- Handle `eventPeerLeave`
- Better architecture?
- Respect `X-RateLimit-Limit` response from webhook (seems to be 2 requests per seconds)
- Publish live status every 5 minutes when there is no traffic? (to update the message timestamp / ensure we don't have missing state)
- Use correct 日本漢字？

Existing problem:
- Race condition after battle finish:

When battle finish, players will enter plaza and `lbsStartLobby` will be triggered.

However, `sharedData.GetMcsUsers()` is still returning they are inside battle.
(In order to solve the duplication right after battle started, I have removed all lobby players *if they are in battle also*, please check [Line 127](https://github.com/inada-s/gdxsv/pull/66/files#diff-bbc193ec510092c18d1667da1c5232f4dfe8137c20b8f99db6b3c1fe606449cdR127) )

So currently it will consider the players are still in battle, and entering the plaza won't update anything until any player join a lobby.

