### PR TITLE
add ping test region in lobby setting

### DIFF
--- a/gdxsv/db.go
+++ b/gdxsv/db.go
@@ -118,7 +118,8 @@ type MLobbySetting struct {
 	RuleID           string `db:"rule_id" json:"rule_id"`
 	EnableForceStart bool   `db:"enable_force_start" json:"enable_force_start"`
 	TeamShuffle      bool   `db:"team_shuffle" json:"team_shuffle"`
-	PingLimit        bool   `db:"ping_limit" json:"ping_limit"`
+	PingLimit        int    `db:"ping_limit" json:"ping_limit"`
+	PingRegion       string `db:"ping_region" json:"ping_region"`
 }
 
 type MRule struct {

--- a/gdxsv/db_sqlite.go
+++ b/gdxsv/db_sqlite.go
@@ -126,6 +126,7 @@ CREATE TABLE IF NOT EXISTS m_lobby_setting
     enable_force_start integer not null,
     team_shuffle       integer not null,
     ping_limit         integer not null,
+    ping_region        text default '',
     PRIMARY KEY (platform, disk, no)
 );
 CREATE TABLE IF NOT EXISTS m_rule

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -810,12 +810,15 @@ var _ = register(lbsPlazaStatus, func(p *LbsPeer, m *LbsMessage) {
 	}
 
 	status := 3 // available
-	if lobby.LobbySetting.PingLimit && lobby.LobbySetting.McsRegion != "" {
-		rtt, err := strconv.Atoi(p.PlatformInfo[lobby.LobbySetting.McsRegion])
+
+	// Check ping from the configured region and prevents the player from entering the lobby if the ping limit is exceeded.
+	if 0 < lobby.LobbySetting.PingLimit && lobby.LobbySetting.PingTestRegion() != "" {
+		rtt, err := strconv.Atoi(p.PlatformInfo[lobby.LobbySetting.PingTestRegion()])
 		if err != nil {
 			rtt = 999
 		}
-		if rtt <= 0 || PingLimitTh <= rtt {
+
+		if rtt <= 0 || lobby.LobbySetting.PingLimit < rtt {
 			status = 1 // not available
 		}
 	}
@@ -833,7 +836,7 @@ var _ = register(lbsPlazaExplain, func(p *LbsPeer, m *LbsMessage) {
 		return
 	}
 
-	rtt := p.PlatformInfo[lobby.LobbySetting.McsRegion]
+	rtt := p.PlatformInfo[lobby.LobbySetting.PingTestRegion()]
 	p.SendMessage(NewServerAnswer(m).Writer().
 		Write16(lobbyID).
 		WriteString(lobby.buildDescription(rtt)).

--- a/gdxsv/lbs_lobby.go
+++ b/gdxsv/lbs_lobby.go
@@ -172,7 +172,7 @@ func (l *LbsLobby) buildDescription(ping string) string {
 	if l.LobbySetting.McsRegion == "best" {
 		locName = "Best Server [Auto Detection]"
 		if 0 < l.LobbySetting.PingLimit && l.LobbySetting.PingTestRegion() != "" {
-			locName = "Best Server [Ping Limited]"
+			locName = "Best Server [Ping Limit]"
 		}
 	}
 

--- a/gdxsv/lbs_lobby.go
+++ b/gdxsv/lbs_lobby.go
@@ -10,11 +10,18 @@ import (
 	"time"
 )
 
-const (
-	PingLimitTh = 64
-)
-
 type LobbySetting MLobbySetting
+
+// PingTestRegion returns region string, which is used to check ping between the region and a peer.
+func (m LobbySetting) PingTestRegion() string {
+	if m.PingRegion != "" {
+		return m.PingRegion
+	}
+	if m.McsRegion != "" && m.McsRegion != "best" {
+		return m.McsRegion
+	}
+	return ""
+}
 
 type LbsLobby struct {
 	app                  *Lbs
@@ -132,11 +139,14 @@ func (l *LbsLobby) buildLobbySettingMessages() []*LbsMessage {
 	var msgs []*LbsMessage
 	msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %v", "LobbyID", l.ID)))
 
-	if l.LobbySetting.PingLimit {
-		msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %v", "PingLimit", boolToYesNo(l.LobbySetting.PingLimit))))
+	if 0 < l.LobbySetting.PingLimit {
+		msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %vms", "PingLimit", l.LobbySetting.PingLimit)))
 	}
 	if l.LobbySetting.McsRegion != "" {
 		msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %v", "McsRegion", l.LobbySetting.McsRegion)))
+	}
+	if l.LobbySetting.PingRegion != "" {
+		msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %v", "PingRegion", l.LobbySetting.PingRegion)))
 	}
 
 	msgs = append(msgs, chatMsg("", "", fmt.Sprintf("%-12s: %v/%v", "Dmage/Diff", l.Rule.DamageLevel+1, l.Rule.Difficulty+1)))
@@ -161,7 +171,11 @@ func (l *LbsLobby) buildDescription(ping string) string {
 	}
 	if l.LobbySetting.McsRegion == "best" {
 		locName = "Best Server [Auto Detection]"
+		if 0 < l.LobbySetting.PingLimit && l.LobbySetting.PingTestRegion() != "" {
+			locName = "Best Server [Ping Limited]"
+		}
 	}
+
 	if ping == "" {
 		return fmt.Sprintf("<B>%s<B><BR><B>%s<END>", locName, l.LobbySetting.Comment)
 	} else {


### PR DESCRIPTION
Combined use both "best server" and "ping limit"
- Add `ping_region` row in `m_lobby_setting`. It will be used to test user's ping from this region.
- Change `ping_limit` type `bool` to `int`, which now means limit millisecond rtt. 0 means no ping limit.
- Use `mcs_region` for ping test if `ping_region` is empty.

