### PR TITLE
support region friendly team shuffle

### DIFF
--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -687,6 +687,7 @@ type LbsPeer struct {
 	PilotName    string
 	Rank         int
 
+	bestRegion    string
 	lastSessionID string
 	lastRecvTime  time.Time
 	left          bool

--- a/gdxsv/lbs.go
+++ b/gdxsv/lbs.go
@@ -247,10 +247,7 @@ func (lbs *Lbs) FindMcsPeer(mcsAddr string) *LbsPeer {
 
 func (lbs *Lbs) Locked(f func(*Lbs)) {
 	c := make(chan interface{})
-	lbs.chEvent <- eventFunc{
-		f: f,
-		c: c,
-	}
+	lbs.chEvent <- eventFunc{f: f, c: c}
 	<-c
 }
 
@@ -366,8 +363,12 @@ func (lbs *Lbs) eventLoop() {
 				lbs.cleanPeer(args.peer)
 				delete(peers, args.peer.Address())
 			case eventFunc:
-				args.f(lbs)
-				args.c <- struct{}{}
+				func() {
+					defer func() {
+						args.c <- nil
+					}()
+					args.f(lbs)
+				}()
 			}
 		case <-tick:
 			for _, p := range peers {

--- a/gdxsv/lbs_handler.go
+++ b/gdxsv/lbs_handler.go
@@ -1562,14 +1562,28 @@ var _ = register(lbsPlatformInfo, func(p *LbsPeer, m *LbsMessage) {
 			p.PlatformInfo[kv[0]] = kv[1]
 		}
 	}
+
 	logger.Info("PlatformInfo", zap.Any("platform_info", p.PlatformInfo))
 	p.logger = p.logger.With(
 		zap.String("flycast", p.PlatformInfo["flycast"]),
 		zap.String("os", p.PlatformInfo["os"]),
 		zap.String("cpu", p.PlatformInfo["cpu"]),
 	)
+
 	if p.PlatformInfo["cpu"] == "x86/64" {
 		p.Platform = PlatformEmuX8664
+	}
+
+	minRtt := 999
+	for region := range gcpLocationName {
+		rtt, err := strconv.Atoi(p.PlatformInfo[region])
+		if err != nil {
+			continue
+		}
+		if 0 < rtt && rtt < minRtt {
+			minRtt = rtt
+			p.bestRegion = region
+		}
 	}
 
 	// pre-sent loginkey

--- a/gdxsv/lbs_lobby_test.go
+++ b/gdxsv/lbs_lobby_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_teamShuffle(t *testing.T) {
+	type args struct {
+		seed  int64
+		peers []*LbsPeer
+	}
+	tests := []struct {
+		name string
+		args args
+		want []uint16
+	}{
+		{
+			name: "random shuffle seed 1",
+			args: args{
+				seed:  1,
+				peers: []*LbsPeer{&LbsPeer{}, &LbsPeer{}, &LbsPeer{}, &LbsPeer{}},
+			},
+			want: []uint16{1, 1, 2, 2},
+		},
+		{
+			name: "random shuffle seed 2",
+			args: args{
+				seed:  2,
+				peers: []*LbsPeer{&LbsPeer{}, &LbsPeer{}, &LbsPeer{}, &LbsPeer{}},
+			},
+			want: []uint16{1, 2, 2, 1},
+		},
+		{
+			name: "region friendly shuffle seed 1",
+			args: args{
+				seed: 1,
+				peers: []*LbsPeer{
+					&LbsPeer{bestRegion: "us-east1"}, &LbsPeer{bestRegion: "us-east1"},
+					&LbsPeer{bestRegion: "us-west1"}, &LbsPeer{bestRegion: "us-west1"}},
+			},
+			want: []uint16{1, 1, 2, 2},
+		},
+		{
+			name: "region friendly shuffle seed 2",
+			args: args{
+				seed: 2,
+				peers: []*LbsPeer{
+					&LbsPeer{bestRegion: "us-east1"}, &LbsPeer{bestRegion: "us-east1"},
+					&LbsPeer{bestRegion: "us-west1"}, &LbsPeer{bestRegion: "us-west1"}},
+			},
+			want: []uint16{2, 2, 1, 1},
+		},
+		{
+			name: "not region friendly shuffle",
+			args: args{
+				seed: 2,
+				peers: []*LbsPeer{
+					&LbsPeer{}, &LbsPeer{bestRegion: "us-east1"},
+					&LbsPeer{bestRegion: "us-west1"}, &LbsPeer{bestRegion: "us-west1"}},
+			},
+			want: []uint16{1, 2, 2, 1},
+		},
+		{
+			name: "two players",
+			args: args{
+				seed:  9,
+				peers: []*LbsPeer{&LbsPeer{}, &LbsPeer{}},
+			},
+			want: []uint16{2, 1},
+		},
+		{
+			name: "three players",
+			args: args{
+				seed:  2,
+				peers: []*LbsPeer{&LbsPeer{}, &LbsPeer{}, &LbsPeer{}},
+			},
+			want: []uint16{1, 2, 2},
+		},
+		{
+			name: "more than five players is not supported",
+			args: args{
+				seed:  1,
+				peers: []*LbsPeer{&LbsPeer{}, &LbsPeer{}, &LbsPeer{}, &LbsPeer{}, &LbsPeer{}},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teams := teamShuffle(tt.args.seed, tt.args.peers)
+			assertEq(t, tt.want, teams)
+		})
+	}
+}

--- a/gdxsv/lbs_mcsfunc.go
+++ b/gdxsv/lbs_mcsfunc.go
@@ -44,6 +44,31 @@ var gcpLocationName = map[string]string{
 	"us-west3":                "Salt Lake City, Utah, USA",
 }
 
+var gcpRegionGroup = map[string]string{
+	"asia-east1":              "asia-east",
+	"asia-east2":              "asia-east",
+	"asia-northeast1":         "asia-northeast",
+	"asia-northeast2":         "asia-northeast",
+	"asia-northeast3":         "asia-northeast",
+	"asia-south1":             "asia-south",
+	"asia-southeast1":         "asia-southeast",
+	"australia-southeast1":    "australia-southeast",
+	"europe-north1":           "europe-north",
+	"europe-west1":            "europe-west",
+	"europe-west2":            "europe-west",
+	"europe-west3":            "europe-west",
+	"europe-west4":            "europe-west",
+	"europe-west6":            "europe-west",
+	"northamerica-northeast1": "northamerica-northeast",
+	"southamerica-east1":      "southamerica-east",
+	"us-central1":             "us-central",
+	"us-east1":                "us-east",
+	"us-east4":                "us-east",
+	"us-west1":                "us-west",
+	"us-west2":                "us-west",
+	"us-west3":                "us-west",
+}
+
 func getMcsFuncClient() (*http.Client, error) {
 	if mcsFuncClientCache != nil && time.Since(mcsFuncClientCreated).Minutes() <= 30.0 {
 		return mcsFuncClientCache, nil

--- a/gdxsv/lbs_test.go
+++ b/gdxsv/lbs_test.go
@@ -348,12 +348,17 @@ disk=2
 maxlag=8
 `).Msg())
 
+	time.Sleep(time.Millisecond) // FIXME
+
+	called := false
 	lbs.Locked(func(*Lbs) {
 		p := lbs.FindPeer(user1.UserID)
-		assertEq(t, p.GameDisk, GameDiskDC2)
-		assertEq(t, p.Platform, PlatformEmuX8664)
-		assertEq(t, p.bestRegion, "asia-northeast1")
+		assertEq(t, GameDiskDC2, p.GameDisk)
+		assertEq(t, PlatformEmuX8664, p.Platform)
+		assertEq(t, "asia-northeast1", p.bestRegion)
+		called = true
 	})
+	assertEq(t, true, called)
 }
 
 func Test100_LoginFlowNewUser(t *testing.T) {

--- a/gdxsv/main.go
+++ b/gdxsv/main.go
@@ -282,7 +282,6 @@ func main() {
 
 	switch command {
 	case "lbs":
-		rand.Seed(time.Now().UnixNano())
 		prepareDB()
 		mainLbs()
 	case "mcs":

--- a/gdxsv/main_test.go
+++ b/gdxsv/main_test.go
@@ -13,7 +13,7 @@ func must(tb testing.TB, err error) {
 	if err != nil {
 		pc, file, line, _ := runtime.Caller(1)
 		name := runtime.FuncForPC(pc).Name()
-		tb.Fatalf("In %s:%d %s\nerr:%vn", file, line, name, err)
+		tb.Errorf("In %s:%d %s\nerr:%vn", file, line, name, err)
 	}
 }
 
@@ -22,7 +22,7 @@ func assertEq(tb testing.TB, expected, actual interface{}) {
 	if !ok {
 		pc, file, line, _ := runtime.Caller(1)
 		name := runtime.FuncForPC(pc).Name()
-		tb.Fatalf("In %s:%d %s\nexpected: %#v \nactual: %#v\n", file, line, name, expected, actual)
+		tb.Errorf("In %s:%d %s\nexpected: %#v \nactual: %#v\n", file, line, name, expected, actual)
 	}
 }
 


### PR DESCRIPTION
Changed the TeamShuffle impl.
When the participants regions are like [JP, JP, HK, HK], players from the same area are chosen to be on the same team like JP, JP vs HK, HK.
Regions other than the above, they will be shuffled randomly.