### PR TITLE
Fix null patch check for lobbies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 work/
 .vscode/
+.idea/
 log.txt
 dump.txt
 gdxsv.db

--- a/gdxsv/lbs_lobby.go
+++ b/gdxsv/lbs_lobby.go
@@ -4,16 +4,17 @@ import (
 	"database/sql"
 	"fmt"
 	"gdxsv/gdxsv/proto"
-	"go.uber.org/zap"
-	"golang.org/x/text/encoding/japanese"
-	"golang.org/x/text/transform"
-	pb "google.golang.org/protobuf/proto"
 	"io/ioutil"
 	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
+	pb "google.golang.org/protobuf/proto"
 )
 
 type LobbySetting MLobbySetting
@@ -613,14 +614,13 @@ func (l *LbsLobby) Update() {
 }
 
 func (l *LbsLobby) makePatchList() *proto.GamePatchList {
-	sp := strings.Split(strings.TrimSpace(l.LobbySetting.PatchNames), ",")
-	if len(sp) == 0 {
+	patches := strings.TrimSpace(l.LobbySetting.PatchNames)
+	if patches == "" {
 		return nil
 	}
 
 	patchList := new(proto.GamePatchList)
-
-	for _, name := range sp {
+	for _, name := range strings.Split(patches, ",") {
 		mPatch, err := getDB().GetPatch(l.Platform, l.GameDisk, name)
 		if err != nil {
 			logger.Warn("failed to load patch", zap.String("name", name), zap.Error(err))


### PR DESCRIPTION
There's a bug in the function that checks for patches where the list of patches is split by ",", then checked for length.
This will always return at least 1 (since the empty string without separator is still a string) instead of the expected 0.

This patch changes the behavior to instead check for an empty string (after trim).

(this is a copy of #181 but from a different branch because I was lazy when setting up that one)