### PR TITLE
Fix mscfunc allocate

### DIFF
--- a/infra/mcsfunc/index.js
+++ b/infra/mcsfunc/index.js
@@ -38,6 +38,7 @@ echo "startup-script"
 
 su -c "echo 'deb http://packages.cloud.google.com/apt google-compute-engine-bionic-stable main' > /etc/apt/sources.list.d/google-compute-engine.list"
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+rm /var/lib/dpkg/lock-frontend
 apt update
 apt -y install google-osconfig-agent jq wget curl
 

--- a/infra/mcsfunc/index.js
+++ b/infra/mcsfunc/index.js
@@ -256,7 +256,7 @@ async function getAlloc(req, res) {
             console.log("trying to create new vm in", zoneName);
             const zone = compute.zone(zoneName);
             const [vm, operation] = await zone.createVM(vmName, {
-                os: "ubuntu-1804",
+                os: "ubuntu-1804-bionic-v",
                 http: true,
                 tags: ["gdxsv-mcs"],
                 machineType: "e2-medium",


### PR DESCRIPTION

<img width="568" alt="image" src="https://user-images.githubusercontent.com/602245/181614751-76795f88-eef8-492d-a5ed-de015ffcd2a0.png">

- Fix `ubuntu-1804` allocating the wrong `ubuntu-1804-bionic-arm64-v20220712` by using `ubuntu-1804-bionic-v` as the prefix
- (Dirty) Fix apt-update error by removing lock file