### PR TITLE
Fix redundant nil check in Mcs.ListenAndServe

### DIFF
--- a/gdxsv/mcs.go
+++ b/gdxsv/mcs.go
@@ -114,17 +114,11 @@ func (mcs *Mcs) ListenAndServe(addr string) {
 	udpSv := NewUDPServer(mcs)
 
 	go func(addr string) {
-		err := tcpSv.ListenAndServe(addr)
-		if err != nil {
-			logger.Fatal("tcpSv.ListenAndServe", zap.Error(err))
-		}
+		logger.Fatal("tcpSv.ListenAndServe", zap.Error(tcpSv.ListenAndServe(addr)))
 	}(addr)
 
 	go func(addr string) {
-		err := udpSv.ListenAndServe(addr)
-		if err != nil {
-			logger.Fatal("udpSv.ListenAndServe", zap.Error(err))
-		}
+		logger.Fatal("udpSv.ListenAndServe", zap.Error(udpSv.ListenAndServe(addr)))
 	}(addr)
 }
 


### PR DESCRIPTION
## Summary
- A newer golangci-lint release now flags `staticcheck SA4023` in `Mcs.ListenAndServe`: `tcpSv.ListenAndServe`/`udpSv.ListenAndServe` only return via an early error path or block forever, so the returned error is never nil, making the `if err != nil` checks always true.
- This is unrelated to any dependency bump, but it currently fails lint on every open dependabot PR since they rebase on master.
- Simplified by passing the error straight to `logger.Fatal`, preserving existing behavior (Fatal only fires when the function returns, i.e. on error).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...`