### PR TITLE
Fix stale Live tab updates on Windows caused by HTTP caching

### DIFF
--- a/gdxsv/lbs_api.go
+++ b/gdxsv/lbs_api.go
@@ -39,6 +39,7 @@ func (lbs *Lbs) RegisterHTTPHandlers() {
 
 	http.HandleFunc("/lbs/status", func(w http.ResponseWriter, r *http.Request) {
 		// Public API: get lobby status
+		w.Header().Set("Cache-Control", "no-store")
 
 		type onlineUser struct {
 			UserID     string `json:"user_id,omitempty"`
@@ -380,6 +381,7 @@ func (lbs *Lbs) RegisterHTTPHandlers() {
 // spectatorsHandler is split out of RegisterHTTPHandlers so it can be
 // exercised directly with httptest.
 func spectatorsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
 	// Public API: how many people are watching one battle. Kept separate from
 	// /lbs/status so a spectator polling during playback does not pull down
 	// every user and every game for one integer.

--- a/gdxsv/lbs_api_cache_test.go
+++ b/gdxsv/lbs_api_cache_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLiveAPI_NoStore(t *testing.T) {
+	savedMux := http.DefaultServeMux
+	http.DefaultServeMux = http.NewServeMux()
+	t.Cleanup(func() { http.DefaultServeMux = savedMux })
+
+	lbs := NewLbs()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lbs.eventLoop()
+	}()
+	t.Cleanup(func() {
+		lbs.Quit()
+		<-done
+	})
+	lbs.RegisterHTTPHandlers()
+
+	for _, tt := range []struct {
+		url    string
+		status int
+	}{
+		{"/lbs/status", http.StatusOK},
+		{"/lbs/spectators?battle_code=unknown", http.StatusOK},
+		{"/lbs/spectators", http.StatusBadRequest},
+	} {
+		t.Run(tt.url, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			http.DefaultServeMux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.url, nil))
+			assertEq(t, tt.status, rec.Code)
+			assertEq(t, "no-store", rec.Result().Header.Get("Cache-Control"))
+		})
+	}
+}

--- a/infra/lbsapi/function.go
+++ b/infra/lbsapi/function.go
@@ -31,6 +31,12 @@ func clearOldCacheLocked() {
 }
 
 func lbsApiHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/status" || r.URL.Path == "/spectators" {
+		// Live polling must reach this handler, even when we serve our own
+		// three-second snapshot below. Do not let clients cache the response.
+		w.Header().Set("Cache-Control", "no-store")
+	}
+
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusBadRequest)
 	}

--- a/infra/lbsapi/function_test.go
+++ b/infra/lbsapi/function_test.go
@@ -1,0 +1,112 @@
+package function
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestLbsAPIHandlerCacheControl(t *testing.T) {
+	savedClient := http.DefaultClient
+	savedCache := cache
+	t.Cleanup(func() {
+		http.DefaultClient = savedClient
+		cache = savedCache
+	})
+
+	for _, tt := range []struct {
+		url          string
+		cacheControl string
+	}{
+		{"/status", "no-store"},
+		{"/spectators?battle_code=battle-a", "no-store"},
+		{"/spectators?battle_code=battle-b", "no-store"},
+		{"/replay", ""},
+		{"/user", ""},
+	} {
+		t.Run(tt.url, func(t *testing.T) {
+			cache = make(map[string]*ResponseCache)
+			calls := 0
+			http.DefaultClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				calls++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			// Both an origin response and a cache hit must carry the policy.
+			for _, fromCache := range []string{"", "yes"} {
+				rec := httptest.NewRecorder()
+				lbsApiHandler(rec, httptest.NewRequest(http.MethodGet, tt.url, nil))
+				header := rec.Result().Header
+				if rec.Code != http.StatusOK || rec.Body.String() != `{"ok":true}` {
+					t.Fatalf("unexpected response: %d %s", rec.Code, rec.Body.String())
+				}
+				if got := header.Get("Cache-Control"); got != tt.cacheControl {
+					t.Errorf("Cache-Control = %q, want %q", got, tt.cacheControl)
+				}
+				if got := header.Get("FromCache"); got != fromCache {
+					t.Errorf("FromCache = %q, want %q", got, fromCache)
+				}
+			}
+			if calls != 1 {
+				t.Fatalf("origin requests = %d, want 1", calls)
+			}
+
+			// The bounded server-side cache still expires normally.
+			cache[tt.url].Time = time.Now().Add(-4 * time.Second)
+			rec := httptest.NewRecorder()
+			lbsApiHandler(rec, httptest.NewRequest(http.MethodGet, tt.url, nil))
+			if calls != 2 || rec.Result().Header.Get("Cache-Control") != tt.cacheControl {
+				t.Fatal("expired response was not refreshed with the expected cache policy")
+			}
+		})
+	}
+}
+
+func TestLbsAPIHandlerErrorsNoStore(t *testing.T) {
+	savedClient := http.DefaultClient
+	savedCache := cache
+	t.Cleanup(func() {
+		http.DefaultClient = savedClient
+		cache = savedCache
+	})
+
+	for _, target := range []string{"/status", "/spectators?battle_code=battle-a"} {
+		for _, networkError := range []bool{false, true} {
+			cache = make(map[string]*ResponseCache)
+			http.DefaultClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if networkError {
+					return nil, errors.New("test connection failure")
+				}
+				return &http.Response{
+					StatusCode: http.StatusServiceUnavailable,
+					Body:       io.NopCloser(strings.NewReader("unavailable")),
+					Header:     make(http.Header),
+				}, nil
+			})}
+			rec := httptest.NewRecorder()
+			lbsApiHandler(rec, httptest.NewRequest(http.MethodGet, target, nil))
+			wantStatus := http.StatusServiceUnavailable
+			if networkError {
+				wantStatus = http.StatusBadRequest
+			}
+			if rec.Code != wantStatus || rec.Result().Header.Get("Cache-Control") != "no-store" {
+				t.Errorf("%s (networkError=%t): status=%d, Cache-Control=%q", target, networkError,
+					rec.Code, rec.Result().Header.Get("Cache-Control"))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Windows clients could keep displaying an outdated Live battle list until Flycast was restarted. Returning `Cache-Control: no-store` fixes this with existing clients, without changing Flycast’s shared HTTP behavior.

- Add `Cache-Control: no-store` to the status and spectator-count endpoints in both LBS and the Cloud Function.
- Include the header on Cloud Function cache hits and error responses.
- Preserve the Cloud Function’s three-second cache and leave unrelated endpoints unchanged.

Both locations need the header because the Cloud Function forwards response bodies without forwarding LBS headers.