### PR TITLE
infra/lbsapi: return after rejecting non-GET requests

### DIFF
--- a/infra/lbsapi/function.go
+++ b/infra/lbsapi/function.go
@@ -39,6 +39,7 @@ func lbsApiHandler(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	key := r.URL.RequestURI()

--- a/infra/lbsapi/function_test.go
+++ b/infra/lbsapi/function_test.go
@@ -110,3 +110,35 @@ func TestLbsAPIHandlerErrorsNoStore(t *testing.T) {
 		}
 	}
 }
+
+func TestLbsAPIHandlerNonGetRejected(t *testing.T) {
+	savedClient := http.DefaultClient
+	savedCache := cache
+	t.Cleanup(func() {
+		http.DefaultClient = savedClient
+		cache = savedCache
+	})
+	cache = make(map[string]*ResponseCache)
+
+	calls := 0
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	rec := httptest.NewRecorder()
+	lbsApiHandler(rec, httptest.NewRequest(http.MethodPost, "/status", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+	if calls != 0 {
+		t.Errorf("origin requests = %d, want 0 (should reject before reaching the origin)", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Noticed while reviewing #404: `lbsApiHandler` writes `400 Bad Request` for non-GET requests but doesn't `return`, so it falls through into the cache lookup and (on a miss) fetches from the origin anyway — wasted work, and a second `WriteHeader` call that Go logs as superfluous. The client still ends up seeing the correct `400` (the first `WriteHeader` wins), so this isn't user-visible, just wasteful.

- Add the missing `return` after `w.WriteHeader(http.StatusBadRequest)`.
- Add `TestLbsAPIHandlerNonGetRejected`, asserting a non-GET request gets `400` with an empty body and never reaches the origin.

## Test plan

- [x] `go test ./infra/lbsapi/...` passes, including the new test