### PR TITLE
infra/lbsapi: document gen2 deploy command

### DIFF
--- a/infra/lbsapi/README.md
+++ b/infra/lbsapi/README.md
@@ -9,9 +9,16 @@ go run cmd/main.go
 ## Deploy
 ```shell
 gcloud functions deploy lbsapi \
+  --gen2 \
   --region asia-northeast1 \
   --entry-point FunctionEntryPoint \
   --trigger-http \
-  --runtime=go120 \
+  --runtime=go127 \
   --allow-unauthenticated
 ```
+
+Deployed as a 2nd gen function (1st gen no longer has a supported Go
+runtime). Check `gcloud functions runtimes list` before bumping
+`--runtime` again; a 1st gen function can't be switched to `--gen2` by
+redeploying under the same name — delete it first, then deploy with
+`--gen2` to get the same URL back.


### PR DESCRIPTION
## Summary

While deploying the latest lbsapi build, found the production function was still on a 3-year-old 1st gen / `go120` deployment — `go120` is no longer in `gcloud functions runtimes list` at all, and every currently-GA Go runtime (go124+) is 2nd gen only.

- Updated the deploy command to `--gen2 --runtime=go127`.
- Noted that an existing 1st gen function can't be switched to gen2 by redeploying under the same name (`gcloud` rejects `--gen2` with "Function already exists in 1st gen, can't change the environment") — it has to be deleted and redeployed to get gen2 with the same URL.

Production `lbsapi` has already been migrated this way and verified live (`/status` and `/spectators` both return 200 with `Cache-Control: no-store`, same `https://asia-northeast1-gdxsv-274515.cloudfunctions.net/lbsapi` URL as before).